### PR TITLE
new feature: add a new param to set the login pages language

### DIFF
--- a/app/src/main/java/com/linecorp/linesdktest/SignInFragment.java
+++ b/app/src/main/java/com/linecorp/linesdktest/SignInFragment.java
@@ -27,6 +27,7 @@ import com.linecorp.linesdktest.settings.TestSetting;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -36,6 +37,7 @@ public class SignInFragment extends Fragment {
     private static final int REQUEST_CODE = 1;
 
     private static final String ARG_KEY_CHANNEL_ID = "channelId";
+    private static final String ARG_KEY_UI_LOCALE = "uiLocale";
 
     private static final String LOG_SEPARATOR = System.getProperty("line.separator");
 
@@ -43,6 +45,9 @@ public class SignInFragment extends Fragment {
 
     @Nullable
     private String channelId;
+
+    @Nullable
+    private Locale uiLocale;
 
     @Nullable
     @BindView(R.id.signin_bot_prompt_normal_radio)
@@ -73,6 +78,7 @@ public class SignInFragment extends Fragment {
         SignInFragment fragment = new SignInFragment();
         Bundle arguments = new Bundle();
         arguments.putString(ARG_KEY_CHANNEL_ID, setting.getChannelId());
+        arguments.putSerializable(ARG_KEY_UI_LOCALE, setting.getUILocale());
         fragment.setArguments(arguments);
         return fragment;
     }
@@ -82,6 +88,7 @@ public class SignInFragment extends Fragment {
         super.onCreate(savedInstanceState);
         Bundle arguments = getArguments();
         channelId = arguments.getString(ARG_KEY_CHANNEL_ID);
+        uiLocale = (Locale) arguments.getSerializable(ARG_KEY_UI_LOCALE);
     }
 
     @Nullable
@@ -151,6 +158,7 @@ public class SignInFragment extends Fragment {
         return new LineAuthenticationParams.Builder()
                 .scopes(getCheckedScopes())
                 .botPrompt(getBotPrompt())
+                .uiLocale(uiLocale)
                 .build();
     }
 

--- a/app/src/main/java/com/linecorp/linesdktest/settings/TestSetting.java
+++ b/app/src/main/java/com/linecorp/linesdktest/settings/TestSetting.java
@@ -3,6 +3,9 @@ package com.linecorp.linesdktest.settings;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.Locale;
 
 public class TestSetting implements Parcelable {
     public static final Parcelable.Creator<TestSetting> CREATOR = new Parcelable.Creator<TestSetting>() {
@@ -20,12 +23,17 @@ public class TestSetting implements Parcelable {
     @NonNull
     private final String channelId;
 
-    public TestSetting(@NonNull String channelId) {
+    @Nullable
+    private final Locale uiLocale;
+
+    public TestSetting(@NonNull String channelId, @Nullable Locale uiLocale) {
         this.channelId = channelId;
+        this.uiLocale = uiLocale;
     }
 
     private TestSetting(@NonNull Parcel in) {
         channelId = in.readString();
+        uiLocale = (Locale) in.readSerializable();
     }
 
     @Override
@@ -36,11 +44,17 @@ public class TestSetting implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(channelId);
+        dest.writeSerializable(uiLocale);
     }
 
     @NonNull
     public String getChannelId() {
         return channelId;
+    }
+
+    @Nullable
+    public Locale getUILocale() {
+        return uiLocale;
     }
 
     @Override
@@ -50,11 +64,14 @@ public class TestSetting implements Parcelable {
 
         TestSetting that = (TestSetting) o;
 
-        return channelId.equals(that.channelId);
+        if (!channelId.equals(that.channelId)) { return false; }
+        return uiLocale != null ? uiLocale.equals(that.uiLocale) : that.uiLocale == null;
     }
 
     @Override
     public int hashCode() {
-        return channelId.hashCode();
+        int result = channelId.hashCode();
+        result = 31 * result + (uiLocale != null ? uiLocale.hashCode() : 0);
+        return result;
     }
 }

--- a/app/src/main/java/com/linecorp/linesdktest/settings/TestSettingManager.java
+++ b/app/src/main/java/com/linecorp/linesdktest/settings/TestSettingManager.java
@@ -5,12 +5,18 @@ import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
+import org.apache.commons.lang3.LocaleUtils;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.Locale;
+
 public final class TestSettingManager {
     private static final String DEFAULT_CHANNEL_ID = "1620019587";
-    private static final TestSetting DEFAULT_SETTING = new TestSetting(DEFAULT_CHANNEL_ID);
+    private static final TestSetting DEFAULT_SETTING = new TestSetting(DEFAULT_CHANNEL_ID, null);
 
     private static final String SHARED_PREFERENCE_KEY = "test_settings";
     private static final String DATA_KEY_PREFIX_CHANNEL_ID = "channel_id_";
+    private static final String DATA_KEY_PREFIX_UI_LOCALE = "ui_locale_";
 
     private TestSettingManager() {
         // To prevent instantiation
@@ -25,13 +31,22 @@ public final class TestSettingManager {
             return DEFAULT_SETTING;
         }
 
-        return new TestSetting(channelId);
+        Locale uiLocale;
+        try {
+            String localeStr = sharedPreferences.getString(DATA_KEY_PREFIX_UI_LOCALE + id, null);
+            uiLocale = LocaleUtils.toLocale(localeStr);
+        } catch (Exception e) {
+            uiLocale = null;
+        }
+
+        return new TestSetting(channelId, uiLocale);
     }
 
     public static void save(@NonNull Context context, int id, @NonNull TestSetting setting) {
         context.getSharedPreferences(SHARED_PREFERENCE_KEY, Context.MODE_PRIVATE)
                .edit()
                .putString(DATA_KEY_PREFIX_CHANNEL_ID + id, setting.getChannelId())
+               .putString(DATA_KEY_PREFIX_UI_LOCALE + id, ObjectUtils.toString(setting.getUILocale(), null))
                .apply();
     }
 }

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -63,6 +63,23 @@
             android:inputType="numberDecimal" />
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/uiLocale" />
+
+        <Spinner
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/uiLocale_spinner" android:layout_weight="1"
+        />
+    </LinearLayout>
+
     <Button
         android:id="@+id/save_settings_btn"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,26 @@
     <string name="clear">Clear</string>
     <string name="clear_log">Clear Log</string>
     <string name="clear_receivers">Clear Friends/Groups</string>
+    <string name="uiLocale">UI Locale</string>
+    <string-array name="supportedLocales">
+        <item>ar</item>
+        <item>de</item>
+        <item>en</item>
+        <item>es</item>
+        <item>es_ES</item>
+        <item>fr</item>
+        <item>in</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>ms</item>
+        <item>pt_BR</item>
+        <item>pt_PT</item>
+        <item>ru</item>
+        <item>th</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh_TW</item>
+        <item>zh_CN</item>
+    </string-array>
 </resources>

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import com.linecorp.linesdk.Scope;
 
 import java.util.List;
+import java.util.Locale;
 
 import static com.linecorp.linesdk.utils.ParcelUtils.readEnum;
 import static com.linecorp.linesdk.utils.ParcelUtils.writeEnum;
@@ -47,14 +48,24 @@ public class LineAuthenticationParams implements Parcelable {
     @Nullable
     private final BotPrompt botPrompt;
 
+    /**
+     * OPTIONAL. <br></br>
+     * The language in which login pages be displayed in. <br></br>
+     * If it is not specified, login pages will use the language setting of user's web browser or LINE App
+     */
+    @Nullable
+    private final Locale uiLocale;
+
     private LineAuthenticationParams(final Builder builder) {
         scopes = builder.scopes;
         botPrompt = builder.botPrompt;
+        uiLocale = builder.uiLocale;
     }
 
     private LineAuthenticationParams(@NonNull final Parcel in) {
         scopes = Scope.convertToScopeList(in.createStringArrayList());
         botPrompt = readEnum(in, BotPrompt.class);
+        uiLocale = (Locale) in.readSerializable();
     }
 
     /**
@@ -66,6 +77,7 @@ public class LineAuthenticationParams implements Parcelable {
     public void writeToParcel(final Parcel dest, final int flags) {
         dest.writeStringList(Scope.convertToCodeList(scopes));
         writeEnum(dest, botPrompt);
+        dest.writeSerializable(uiLocale);
     }
 
     /**
@@ -97,6 +109,15 @@ public class LineAuthenticationParams implements Parcelable {
     }
 
     /**
+     * Gets the language in which login pages be displayed in.
+     * @return The language in which login pages be displayed in.
+     */
+    @Nullable
+    public Locale getUILocale() {
+        return uiLocale;
+    }
+
+    /**
      * Represents an option to determine how to prompt the user to add a bot as a friend during the
      * login process.
      */
@@ -119,6 +140,7 @@ public class LineAuthenticationParams implements Parcelable {
     public static final class Builder {
         private List<Scope> scopes;
         private BotPrompt botPrompt;
+        private Locale uiLocale;
 
         public Builder() {}
 
@@ -139,6 +161,17 @@ public class LineAuthenticationParams implements Parcelable {
          */
         public Builder botPrompt(final BotPrompt val) {
             botPrompt = val;
+            return this;
+        }
+
+        /**
+         * Sets the language in which login pages be displayed in. <br></br>
+         * If it is not specified, login pages will use the language setting of user's web browser or LINE App
+         * @param val The language in which login pages be displayed in.
+         * @return The builder itself.
+         */
+        public Builder uiLocale(final Locale val) {
+            uiLocale = val;
             return this;
         }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -162,6 +162,9 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
                 "returnUri", returnUri,
                 "loginChannelId", config.getChannelId()
         );
+        if (params.getUILocale() != null) {
+            loginQueryParams.put("ui_locales", params.getUILocale().toString());
+        }
         final Uri loginUri = appendQueryParams(config.getWebLoginPageUrl(), loginQueryParams);
         return loginUri;
     }


### PR DESCRIPTION
this is for issue #15

Change List:
(1) added a new param `uiLocale` to class `LineAuthenticationParams`, to customize the login pages languages
(2) added a new `uiLocaleSpinner` to Test App,  to customize the login pages languages