### PR TITLE
HOTFIX: Invalid id generation on a single XML

### DIFF
--- a/line-sdk/src/main/res/layout/dialog_send_message.xml
+++ b/line-sdk/src/main/res/layout/dialog_send_message.xml
@@ -52,11 +52,11 @@
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/horizontalScrollView"
+        app:layout_constraintBottom_toTopOf="@+id/horizontalScrollView"
         app:layout_constraintTop_toBottomOf="@id/tabLayout" />
 
     <HorizontalScrollView
-        android:id="@+id/horizontalScrollView"
+        android:id="@id/horizontalScrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fadingEdge="none"


### PR DESCRIPTION
## Changes

In `dialog_send_message.xml`, `horizontalScrollView` id creation part was moved to upper.

## Reason

It makes an error on certain build environment like NVIDIA CodeWorks 1R8. Therefore, it is safe to create new id at the upper-most reference.

After I built a custom AAR with this change, it passed the resource processing task with AAPT.