### PR TITLE
remove un-necesary exception

### DIFF
--- a/line-sdk/src/main/java/com/linecorp/linesdk/Scope.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/Scope.java
@@ -115,10 +115,6 @@ public class Scope {
     private final String code;
 
     public Scope(@NonNull final String code) {
-        if (scopeInstanceMap.containsKey(code)) {
-            throw new IllegalArgumentException("Scope code already exists: " + code);
-        }
-
         this.code = code;
         scopeInstanceMap.put(code, this);
     }


### PR DESCRIPTION
## Summary
When new Scope instance is created, originally, it will check whether the same Scope is created before; if so, throw exception. However, this is not so serious to throw an exception here. So, we remove the exception.
