### PR TITLE
check if intent can be handled before passing to activity

### DIFF
--- a/app/src/main/java/com/linecorp/linesdktest/settings/TestSettingManager.java
+++ b/app/src/main/java/com/linecorp/linesdktest/settings/TestSettingManager.java
@@ -2,13 +2,14 @@ package com.linecorp.linesdktest.settings;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import androidx.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Locale;
+
+import androidx.annotation.NonNull;
 
 public final class TestSettingManager {
     private static final String DEFAULT_CHANNEL_ID = "1620019587";

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
@@ -3,15 +3,9 @@ package com.linecorp.linesdk.auth.internal;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-
-import androidx.annotation.MainThread;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import com.linecorp.linesdk.LineAccessToken;
 import com.linecorp.linesdk.LineApiResponse;
@@ -33,6 +27,11 @@ import com.linecorp.linesdk.internal.nwclient.TalkApiClient;
 import com.linecorp.linesdk.internal.pkce.PKCECode;
 
 import java.util.List;
+
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 /**
  * This class controls LINE authentication flow.
@@ -109,30 +108,13 @@ import java.util.List;
         final PKCECode pkceCode = createPKCECode();
         authenticationStatus.setPKCECode(pkceCode);
         try {
-            BrowserAuthenticationApi.Request request = browserAuthenticationApi
-                    .getRequest(activity, config, pkceCode, params);
+            BrowserAuthenticationApi.Request request = browserAuthenticationApi.getRequest(activity, config, pkceCode, params);
             if (request.isLineAppAuthentication()) {
-                // "launchMode" of the activity launched by the follows is "singleInstance".
-                // So, we must not use startActivityForResult.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                    activity.startActivity(
-                            request.getIntent(),
-                            request.getStartActivityOptions());
-                } else {
-                    activity.startActivity(request.getIntent());
-                }
+                activity.startActivity(request.getIntent(), request.getStartActivityOptions());
             } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                    activity.startActivityForResult(
-                            request.getIntent(),
-                            REQUEST_CODE,
-                            request.getStartActivityOptions());
-                } else {
-                    activity.startActivityForResult(
-                            request.getIntent(),
-                            REQUEST_CODE);
-                }
+                activity.startActivityForResult(request.getIntent(), REQUEST_CODE, request.getStartActivityOptions());
             }
+
             authenticationStatus.setSentRedirectUri(request.getRedirectUri());
         } catch (ActivityNotFoundException e) {
             authenticationStatus.authenticationIntentHandled();


### PR DESCRIPTION
## Issue ##

Sometimes, app encounters ActivityNotfoundException when trying to login by installed LINE app.
```
LineApiError{httpResponseCode=-1, message='android.content.ActivityNotFoundException: No Activity found to handle Intent
{ act=android.intent.action.VIEW dat=https://access.line.me/... pkg=jp.naver.line.android }

at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1805)
at android.app.Instrumentation.execStartActivity(Instrumentation.java:1514)
at android.app.Activity.startActivityForResult(Activity.java:3950)
at android.app.Activity.startActivityForResult(Activity.java:3911)
at android.app.Activity.startActivity(Activity.java:4234)
at com.linecorp.linesdk.auth.internal.LineAuthenticationController$RequestTokenRequestTask.onPostExecute()
...
```

## Solution ##

Check if system has component to handle the intent before passing out the created intent.
