### PR TITLE
Add detail error code for internal errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "com.linecorp.linesdktest"
-        minSdkVersion 18
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
-version = "5.5.1"
+version = "5.6.0"
 
 publish {
     userOrg = 'line'
@@ -23,9 +23,9 @@ android {
     publishNonDefault true
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 19
         targetSdkVersion 29
-        versionCode 5_05_01
+        versionCode 5_06_00
         versionName version
 
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/line-sdk/src/main/java/com/linecorp/linesdk/LineApiError.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/LineApiError.java
@@ -5,6 +5,7 @@ import android.os.Parcelable;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Objects;
 
 import androidx.annotation.Nullable;
 
@@ -24,9 +25,21 @@ public class LineApiError implements Parcelable {
         }
     };
 
+    /**
+     * Represents detail error reasons.
+     */
     public enum ErrorCode {
+        /**
+         * Login intent can't be handled by system.
+         */
         LOGIN_ACTIVITY_NOT_FOUND,
+        /**
+         * Http response result can't be successfully parsed.
+         */
         HTTP_RESPONSE_PARSE_ERROR,
+        /**
+         * The default value when the detail error reason is not defined yet.
+         */
         NOT_DEFINED,
     }
 
@@ -126,6 +139,27 @@ public class LineApiError implements Parcelable {
         this.message = in.readString();
         int tmpErrorCode = in.readInt();
         this.errorCode = tmpErrorCode == -1 ? null : ErrorCode.values()[tmpErrorCode];
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LineApiError)) return false;
+        LineApiError that = (LineApiError) o;
+        return getHttpResponseCode() == that.getHttpResponseCode() &&
+                Objects.equals(getMessage(), that.getMessage()) &&
+                errorCode == that.errorCode;
+    }
+
+    /**
+     * @hide
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getHttpResponseCode(), getMessage(), errorCode);
     }
 
     /**

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineLoginResult.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineLoginResult.java
@@ -2,8 +2,6 @@ package com.linecorp.linesdk.auth;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.linecorp.linesdk.LineApiError;
 import com.linecorp.linesdk.LineApiResponse;
@@ -11,6 +9,11 @@ import com.linecorp.linesdk.LineApiResponseCode;
 import com.linecorp.linesdk.LineCredential;
 import com.linecorp.linesdk.LineIdToken;
 import com.linecorp.linesdk.LineProfile;
+
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.linecorp.linesdk.utils.ParcelUtils.readEnum;
 import static com.linecorp.linesdk.utils.ParcelUtils.writeEnum;
@@ -210,27 +213,17 @@ public class LineLoginResult implements Parcelable {
      * @hide
      */
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
-
-        final LineLoginResult that = (LineLoginResult) o;
-
-        if (responseCode != that.responseCode) { return false; }
-        if (nonce != null ? !nonce.equals(that.nonce) : that.nonce != null) { return false; }
-        if (lineProfile != null ? !lineProfile.equals(that.lineProfile) : that.lineProfile != null) {
-            return false;
-        }
-        if (lineIdToken != null ? !lineIdToken.equals(that.lineIdToken) : that.lineIdToken != null) {
-            return false;
-        }
-        if (friendshipStatusChanged != null ? !friendshipStatusChanged.equals(that.friendshipStatusChanged) :
-            that.friendshipStatusChanged != null) { return false; }
-        if (lineCredential != null ? !lineCredential.equals(that.lineCredential) :
-            that.lineCredential != null) {
-            return false;
-        }
-        return errorData.equals(that.errorData);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LineLoginResult)) return false;
+        LineLoginResult that = (LineLoginResult) o;
+        return getResponseCode() == that.getResponseCode() &&
+                Objects.equals(getNonce(), that.getNonce()) &&
+                Objects.equals(getLineProfile(), that.getLineProfile()) &&
+                Objects.equals(getLineIdToken(), that.getLineIdToken()) &&
+                Objects.equals(getFriendshipStatusChanged(), that.getFriendshipStatusChanged()) &&
+                Objects.equals(getLineCredential(), that.getLineCredential()) &&
+                getErrorData().equals(that.getErrorData());
     }
 
     /**
@@ -238,14 +231,14 @@ public class LineLoginResult implements Parcelable {
      */
     @Override
     public int hashCode() {
-        int result = responseCode.hashCode();
-        result = 31 * result + (nonce != null ? nonce.hashCode() : 0);
-        result = 31 * result + (lineProfile != null ? lineProfile.hashCode() : 0);
-        result = 31 * result + (lineIdToken != null ? lineIdToken.hashCode() : 0);
-        result = 31 * result + (friendshipStatusChanged != null ? friendshipStatusChanged.hashCode() : 0);
-        result = 31 * result + (lineCredential != null ? lineCredential.hashCode() : 0);
-        result = 31 * result + errorData.hashCode();
-        return result;
+        return Objects.hash(
+                getResponseCode(),
+                getNonce(),
+                getLineProfile(),
+                getLineIdToken(),
+                getFriendshipStatusChanged(),
+                getLineCredential(),
+                getErrorData());
     }
 
     /**

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
@@ -8,6 +8,7 @@ import android.os.Looper;
 import android.text.TextUtils;
 
 import com.linecorp.linesdk.LineAccessToken;
+import com.linecorp.linesdk.LineApiError;
 import com.linecorp.linesdk.LineApiResponse;
 import com.linecorp.linesdk.LineCredential;
 import com.linecorp.linesdk.LineIdToken;
@@ -118,7 +119,7 @@ import androidx.annotation.VisibleForTesting;
             authenticationStatus.setSentRedirectUri(request.getRedirectUri());
         } catch (ActivityNotFoundException e) {
             authenticationStatus.authenticationIntentHandled();
-            activity.onAuthenticationFinished(LineLoginResult.internalError(e));
+            activity.onAuthenticationFinished(LineLoginResult.internalError(new LineApiError(e, LineApiError.ErrorCode.LOGIN_ACTIVITY_NOT_FOUND)));
         }
     }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/internal/nwclient/core/ChannelServiceHttpClient.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/internal/nwclient/core/ChannelServiceHttpClient.java
@@ -5,11 +5,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.annotation.WorkerThread;
-
 import com.linecorp.android.security.TLSSocketFactory;
 import com.linecorp.linesdk.BuildConfig;
 import com.linecorp.linesdk.LineApiError;
@@ -31,6 +26,11 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import javax.net.ssl.HttpsURLConnection;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.annotation.WorkerThread;
 
 import static com.linecorp.linesdk.utils.UriUtils.appendQueryParams;
 
@@ -347,7 +347,7 @@ public class ChannelServiceHttpClient {
                     && httpResponseCode != HttpURLConnection.HTTP_NO_CONTENT) {
                 return LineApiResponse.createAsError(
                         LineApiResponseCode.SERVER_ERROR,
-                        new LineApiError(
+                        LineApiError.createWithHttpResponseCode(
                                 httpResponseCode,
                                 errorResponseParser.getResponseData(inputStream)));
             }
@@ -361,7 +361,8 @@ public class ChannelServiceHttpClient {
             // Evaluates response data parsing error as INTERNAL_ERROR
             return LineApiResponse.createAsError(
                     LineApiResponseCode.INTERNAL_ERROR,
-                    new LineApiError(httpResponseCode, e));
+                    new LineApiError(e, LineApiError.ErrorCode.HTTP_RESPONSE_PARSE_ERROR)
+            );
         }
     }
 

--- a/line-sdk/src/test/java/com/linecorp/linesdk/LineApiErrorTest.java
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/LineApiErrorTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 public class LineApiErrorTest {
     @Test
     public void testParcelable() {
-        LineApiError expected = new LineApiError(5, "testMessage");
+        LineApiError expected = LineApiError.createWithHttpResponseCode(5, "testMessage");
 
         Parcel parcel = Parcel.obtain();
         expected.writeToParcel(parcel, 0);
@@ -31,10 +31,10 @@ public class LineApiErrorTest {
 
     @Test
     public void testEquals() {
-        LineApiError expected = new LineApiError(5, "testMessage");
+        LineApiError expected = LineApiError.createWithHttpResponseCode(5, "testMessage");
 
-        assertTrue(expected.equals(new LineApiError(5, "testMessage")));
-        assertFalse(expected.equals(new LineApiError(4, "testMessage")));
-        assertFalse(expected.equals(new LineApiError(5, "testMessage2")));
+        assertTrue(expected.equals(LineApiError.createWithHttpResponseCode(5, "testMessage")));
+        assertFalse(expected.equals(LineApiError.createWithHttpResponseCode(4, "testMessage")));
+        assertFalse(expected.equals(LineApiError.createWithHttpResponseCode(5, "testMessage2")));
     }
 }

--- a/line-sdk/src/test/java/com/linecorp/linesdk/api/internal/AutoRefreshLineApiClientProxyTest.java
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/api/internal/AutoRefreshLineApiClientProxyTest.java
@@ -1,8 +1,5 @@
 package com.linecorp.linesdk.api.internal;
 
-import androidx.annotation.NonNull;
-
-import com.linecorp.linesdk.BuildConfig;
 import com.linecorp.linesdk.LineApiError;
 import com.linecorp.linesdk.LineApiResponse;
 import com.linecorp.linesdk.LineApiResponseCode;
@@ -21,6 +18,8 @@ import org.robolectric.annotation.Config;
 
 import java.net.HttpURLConnection;
 
+import androidx.annotation.NonNull;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
@@ -37,7 +36,7 @@ public class AutoRefreshLineApiClientProxyTest {
     private static class Results {
         private static final LineApiResponse<?> UNAUTHORIZED = LineApiResponse.createAsError(
                 LineApiResponseCode.SERVER_ERROR,
-                new LineApiError(HttpURLConnection.HTTP_UNAUTHORIZED, "errorMessage"));
+                LineApiError.createWithHttpResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED, "errorMessage"));
         private static final LineApiResponse<?> NETWORK_ERROR = LineApiResponse.createAsError(
                 LineApiResponseCode.NETWORK_ERROR,
                 LineApiError.DEFAULT);

--- a/line-sdk/src/test/java/com/linecorp/linesdk/auth/LineLoginResultTest.java
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/auth/LineLoginResultTest.java
@@ -3,8 +3,6 @@ package com.linecorp.linesdk.auth;
 import android.net.Uri;
 import android.os.Parcel;
 
-import androidx.annotation.NonNull;
-
 import com.linecorp.linesdk.LineAccessToken;
 import com.linecorp.linesdk.LineApiError;
 import com.linecorp.linesdk.LineApiResponseCode;
@@ -22,6 +20,8 @@ import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Date;
+
+import androidx.annotation.NonNull;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;


### PR DESCRIPTION
## Summary

Add errorCode for LineApiError class, so that when internal error happens, it's easier to identify what kind of error it is by checking the errorCode enum type.

Currently supported types are
```java
    public enum ErrorCode {
        LOGIN_ACTIVITY_NOT_FOUND, // when line-sdk can't find Activity that supports login intent.
        HTTP_RESPONSE_PARSE_ERROR, // when line-sdk can't parse http response from line login server.
        NOT_DEFINED, // when error code is not defined.
    }
```
