### PR TITLE
add necessary query section in AndroidManifest.xml

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         applicationId "com.linecorp.linesdktest"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -18,13 +18,13 @@ publish {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.2'
     publishNonDefault true
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 5_06_00
         versionName version
 

--- a/line-sdk/src/main/AndroidManifest.xml
+++ b/line-sdk/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.linecorp.linesdk">
+    <queries>
+        <package android:name="jp.naver.line.android" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 
     <application
         android:allowBackup="false"


### PR DESCRIPTION
* upgrade android build tools to 30.0.2
* update sample app's targetSdk to 30, so that Android 11's new changes can be verified.
* add necessary `<queries>` section in AndroidManifest.xml for Android 11's package visibility change.