### PR TITLE
add back javadoc tasks

### DIFF
--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -255,17 +255,6 @@ task javadoc_internal(type: Javadoc) {
     }
 }
 
-// Avoid Kotlin docs error
-tasks.withType(Javadoc) {
-    enabled = false
-}
-
-// Remove javadoc related tasks
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
 // https://github.com/bintray/gradle-bintray-plugin
 bintray {
     user = project.hasProperty('bintrayUser') ? project.bintrayUser : System.getenv('bintrayUser')

--- a/line-sdk/src/main/java/com/linecorp/linesdk/LineApiError.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/LineApiError.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Objects;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
@@ -129,6 +130,16 @@ public class LineApiError implements Parcelable {
     @Nullable
     public String getMessage() {
         return message;
+    }
+
+    /**
+     * Gets the error code associated with the API error.
+     *
+     * @return The error code associated with the API error.
+     */
+    @NonNull
+    public ErrorCode getErrorCode() {
+        return errorCode;
     }
 
     /**


### PR DESCRIPTION
ISSUE:
Originally javadoc may build fail when trying to run bintrayUpload task in gradle; so it's disabled.
However, in order to generate javadoc_public task for API reference, we still need to enable javadoc task.

Will check why it fails to build javadoc in bintrayUpload task, and fix it directly instead of disabling javadoc task.
