### PR TITLE
Update header navigation links

### DIFF
--- a/templates/components/masthead.cs
+++ b/templates/components/masthead.cs
@@ -2,17 +2,13 @@
 <div id="header">
     <div id="headerLeft">
       <div class="d-flex align-items-center">
-        <a id="masthead-title" href="https://developers.line.biz/en/reference/">
+        <a id="masthead-title" href="https://developers.line.biz/en/reference/android-sdk/">
           LINE SDK Docs
         </a>
         <nav class="GlobalHeaderNav">
           <ul>
-            <li><a class="GlobalHeaderNavLink" href="/en/services/" data-navlink="services" data-translate="translate_header_menu_service">Products</a></li>
-            <li><a class="GlobalHeaderNavLink" href="/en/docs/" data-navlink="docs" data-translate="translate_header_menu_documents">Documents</a></li>
-            <li><a class="GlobalHeaderNavLink" href="/en/news/" data-navlink="news" data-translate="translate_header_menu_news">News</a></li>
-            <li><a class="GlobalHeaderNavLink" href="/en/faq/" data-navlink="faq" data-translate="translate_header_menu_faq">FAQ</a></li>
-            <li><a class="GlobalHeaderNavLink Link-blank" href="https://www.line-community.me/" target="_blank" data-translate="translate_header_menu_community">Community</a></li>
-            <li><a class="GlobalHeaderNavLink Link-blank" href="https://engineering.linecorp.com/en/blog/" target="_blank" data-translate="translate_header_menu_blog">Blog</a></li>
+            <li><a class="GlobalHeaderNavLink Link-blank" href="/en/" target="_blank" data-navlink="docs_site" data-translate="translate_header_menu_docs_site">LINE Developers Site</a></li>
+            <li><a class="GlobalHeaderNavLink Link-blank" href="https://github.com/line/line-sdk-android/releases" target="_blank">Releases</a></li>
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
## Changes

Updated the header navigation:
- Title link _LINE SDK Docs_ now points to [Android reference top](https://developers.line.biz/en/reference/android-sdk/) (and not [Developers Site references overview](https://developers.line.biz/en/reference/) anymore)
- Header links changed to _LINE Developers Site_ and _github releases page_

![Screen Shot 2020-10-21 at 14 15 22](https://user-images.githubusercontent.com/7602082/96676674-d857d380-13a8-11eb-99ac-797101f37ee1.png)
