### PR TITLE
Configure API urls via LineEnvConfig; bump lib version to v5.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Create your own LINE Channel and follow the instructions [here](https://develope
 Setup current line-sdk version
 
 ```
-linesdk_version = '5.4.0'
+linesdk_version = '5.6.2'
 ```
 
-Add Jcenter to your repositories if it's not added yet.
+Add mavenCentral to your repositories if it's not added yet.
 
 ```gradle
 repositories {
     ...
-	jcenter()    
+	mavenCentral()
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
 
 dependencies {
     implementation project(':line-sdk')
-    //implementation 'com.linecorp.linesdk:linesdk:5.6.1'
+    //implementation 'com.linecorp.linesdk:linesdk:5.6.2'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${ver.kotlin}"
 

--- a/app/src/main/java/com/linecorp/linesdktest/InternalApisFragment.java
+++ b/app/src/main/java/com/linecorp/linesdktest/InternalApisFragment.java
@@ -19,6 +19,11 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.constraintlayout.widget.Group;
+
 import com.linecorp.linesdk.ActionResult;
 import com.linecorp.linesdk.FriendSortField;
 import com.linecorp.linesdk.GetFriendsResponse;
@@ -56,10 +61,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.constraintlayout.widget.Group;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -357,8 +358,7 @@ public class InternalApisFragment extends BaseApisFragment implements SendMessag
     void createChatroomWithUi() {
         Intent intent = CreateOpenChatActivity.createIntent(
             getActivity(),
-            channelId,
-            BuildConfig.API_SERVER_BASE_URI);
+            channelId);
 
         startActivityForResult(intent, REQUEST_CODE_CREATE_OPEN_CHATROOM);
     }

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -89,7 +89,7 @@ dependencies {
 
     // for tests
     testImplementation "junit:junit:${ver.jUnit}"
-    testImplementation "org.mockito:mockito-core:${ver.mockito}"
+    testImplementation "org.mockito:mockito-inline:${ver.mockito}"
     testImplementation "org.robolectric:robolectric:${ver.robolectric}"
 
     // for @hide annotation on functions to hide it from javadoc

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group = "com.linecorp.linesdk"
-version = "5.6.1"
+version = "5.6.2"
 
 android {
     compileSdkVersion 30
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 30
-        versionCode 5_06_01
+        versionCode 5_06_02
         versionName version
 
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/line-sdk/consumer-proguard-rules.pro
+++ b/line-sdk/consumer-proguard-rules.pro
@@ -30,3 +30,10 @@
 # start for jjwt library
 -keep class io.jsonwebtoken.** { *; }
 
+-keep class com.linecorp.linesdk.api.LineEnvConfig {
+    *;
+}
+
+-keep class com.linecorp.linesdk.ManifestParser {
+    public protected *;
+}

--- a/line-sdk/src/main/java/com/linecorp/linesdk/Constants.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/Constants.java
@@ -5,7 +5,4 @@ package com.linecorp.linesdk;
  * */
 public class Constants {
     public static final String LINE_APP_PACKAGE_NAME = "jp.naver.line.android";
-    public static final String OPENID_DISCOVERY_DOCUMENT_URL = "https://access.line.me/.well-known/openid-configuration";
-    public static final String API_SERVER_BASE_URI = "https://api.line.me/";
-    public static final String WEB_LOGIN_PAGE_URL = "https://access.line.me/oauth2/v2.1/login";
 }

--- a/line-sdk/src/main/java/com/linecorp/linesdk/ManifestParser.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/ManifestParser.kt
@@ -1,0 +1,59 @@
+package com.linecorp.linesdk
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.annotation.CheckResult
+import androidx.annotation.RestrictTo
+import com.linecorp.linesdk.api.LineEnvConfig
+
+private const val LINE_ENV_CONFIG = "LineEnvConfig"
+
+/**
+ * Parse [LineEnvConfig] reference out of the AndroidManifest file.
+ *
+ * @hide
+ * */
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+internal class ManifestParser {
+
+    /**
+     * Parse meta-data value in AndroidManifest.xml, retrieve a [LineEnvConfig] instance if key
+     * *LineEnvConfig* is presented in the meta-data.
+     *
+     * @return *null* if something went wrong or a [LineEnvConfig] instance instead.
+     * */
+    @CheckResult
+    fun parse(context: Context): LineEnvConfig? {
+        return runCatching {
+            context.packageManager
+                .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
+                .metaData
+                ?.getString(LINE_ENV_CONFIG)
+                ?.let { className ->
+                    parseEnvConfig(className)
+                }
+        }.getOrNull()
+    }
+
+    private fun parseEnvConfig(className: String): LineEnvConfig {
+        val clazz: Class<*>
+        try {
+            clazz = Class.forName(className)
+        } catch (e: ClassNotFoundException) {
+            throw IllegalArgumentException("Unable to find LineEnvConfig implementation", e)
+        }
+
+        val config: Any
+        try {
+            config = clazz.newInstance()
+        } catch (e: ReflectiveOperationException) {
+            throw RuntimeException(
+                "Unable to instantiate LineEnvConfig implementation for $clazz", e
+            )
+        }
+        if (config !is LineEnvConfig) {
+            throw RuntimeException("Expected instanceof LineEnvConfig, but found: $config")
+        }
+        return config
+    }
+}

--- a/line-sdk/src/main/java/com/linecorp/linesdk/api/LineApiClientBuilder.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/api/LineApiClientBuilder.java
@@ -14,7 +14,6 @@ import com.linecorp.linesdk.internal.AccessTokenCache;
 import com.linecorp.linesdk.internal.EncryptorHolder;
 import com.linecorp.linesdk.internal.nwclient.LineAuthenticationApiClient;
 import com.linecorp.linesdk.internal.nwclient.TalkApiClient;
-import com.linecorp.linesdk.utils.ObjectUtils;
 
 /**
  * Represents a builder for creating {@link LineApiClient} objects with the desired settings.
@@ -87,9 +86,9 @@ public class LineApiClientBuilder {
     @Deprecated
     @NonNull
     public LineApiClientBuilder openidDiscoveryDocumentUrl(@Nullable final Uri openidDiscoveryDocumentUrl) {
-        this.openidDiscoveryDocumentUrl =
-                ObjectUtils.defaultIfNull(openidDiscoveryDocumentUrl,
-                        Uri.parse(new LineDefaultEnvConfig().getOpenIdDiscoveryDocumentUrl()));
+        if (openidDiscoveryDocumentUrl != null) {
+            this.openidDiscoveryDocumentUrl = openidDiscoveryDocumentUrl;
+        }
         return this;
     }
     /**
@@ -99,9 +98,9 @@ public class LineApiClientBuilder {
     @Deprecated
     @NonNull
     public LineApiClientBuilder apiBaseUri(@Nullable final Uri apiBaseUri) {
-        this.apiBaseUri =
-                ObjectUtils.defaultIfNull(apiBaseUri,
-                        Uri.parse(new LineDefaultEnvConfig().getApiServerBaseUri()));
+        if (apiBaseUri != null) {
+            this.apiBaseUri = apiBaseUri;
+        }
         return this;
     }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/api/LineApiClientBuilder.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/api/LineApiClientBuilder.java
@@ -4,7 +4,11 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.linecorp.linesdk.Constants;
+import com.linecorp.linesdk.ManifestParser;
 import com.linecorp.linesdk.api.internal.AutoRefreshLineApiClientProxy;
 import com.linecorp.linesdk.api.internal.LineApiClientImpl;
 import com.linecorp.linesdk.internal.AccessTokenCache;
@@ -12,9 +16,6 @@ import com.linecorp.linesdk.internal.EncryptorHolder;
 import com.linecorp.linesdk.internal.nwclient.LineAuthenticationApiClient;
 import com.linecorp.linesdk.internal.nwclient.TalkApiClient;
 import com.linecorp.linesdk.utils.ObjectUtils;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * Represents a builder for creating {@link LineApiClient} objects with the desired settings.
@@ -44,8 +45,15 @@ public class LineApiClientBuilder {
         }
         this.context = context.getApplicationContext();
         this.channelId = channelId;
-        openidDiscoveryDocumentUrl = Uri.parse(Constants.OPENID_DISCOVERY_DOCUMENT_URL);
-        apiBaseUri = Uri.parse(Constants.API_SERVER_BASE_URI);
+
+        ManifestParser parser = new ManifestParser();
+        LineEnvConfig config = parser.parse(context);
+        if (config == null) {
+            config = new LineDefaultEnvConfig();
+        }
+
+        openidDiscoveryDocumentUrl = Uri.parse(config.getOpenIdDiscoveryDocumentUrl());
+        apiBaseUri = Uri.parse(config.getApiServerBaseUri());
     }
 
     /**
@@ -77,6 +85,7 @@ public class LineApiClientBuilder {
      * @param openidDiscoveryDocumentUrl The URI to set.
      * @return The current {@link LineApiClientBuilder} instance.
      */
+    @Deprecated
     @NonNull
     public LineApiClientBuilder openidDiscoveryDocumentUrl(@Nullable final Uri openidDiscoveryDocumentUrl) {
         this.openidDiscoveryDocumentUrl =
@@ -87,8 +96,8 @@ public class LineApiClientBuilder {
     /**
      * @hide
      * Sets the API base URI.
-     *
      */
+    @Deprecated
     @NonNull
     public LineApiClientBuilder apiBaseUri(@Nullable final Uri apiBaseUri) {
         this.apiBaseUri = ObjectUtils.defaultIfNull(apiBaseUri, Uri.parse(Constants.API_SERVER_BASE_URI));

--- a/line-sdk/src/main/java/com/linecorp/linesdk/api/LineApiClientBuilder.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/api/LineApiClientBuilder.java
@@ -7,7 +7,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.linecorp.linesdk.Constants;
 import com.linecorp.linesdk.ManifestParser;
 import com.linecorp.linesdk.api.internal.AutoRefreshLineApiClientProxy;
 import com.linecorp.linesdk.api.internal.LineApiClientImpl;
@@ -90,7 +89,7 @@ public class LineApiClientBuilder {
     public LineApiClientBuilder openidDiscoveryDocumentUrl(@Nullable final Uri openidDiscoveryDocumentUrl) {
         this.openidDiscoveryDocumentUrl =
                 ObjectUtils.defaultIfNull(openidDiscoveryDocumentUrl,
-                        Uri.parse(Constants.OPENID_DISCOVERY_DOCUMENT_URL));
+                        Uri.parse(new LineDefaultEnvConfig().getOpenIdDiscoveryDocumentUrl()));
         return this;
     }
     /**
@@ -100,7 +99,9 @@ public class LineApiClientBuilder {
     @Deprecated
     @NonNull
     public LineApiClientBuilder apiBaseUri(@Nullable final Uri apiBaseUri) {
-        this.apiBaseUri = ObjectUtils.defaultIfNull(apiBaseUri, Uri.parse(Constants.API_SERVER_BASE_URI));
+        this.apiBaseUri =
+                ObjectUtils.defaultIfNull(apiBaseUri,
+                        Uri.parse(new LineDefaultEnvConfig().getApiServerBaseUri()));
         return this;
     }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/api/LineDefaultEnvConfig.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/api/LineDefaultEnvConfig.kt
@@ -1,0 +1,9 @@
+package com.linecorp.linesdk.api
+
+import androidx.annotation.RestrictTo
+
+/**
+ * @hide
+ * */
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+internal class LineDefaultEnvConfig : LineEnvConfig()

--- a/line-sdk/src/main/java/com/linecorp/linesdk/api/LineEnvConfig.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/api/LineEnvConfig.kt
@@ -1,0 +1,10 @@
+package com.linecorp.linesdk.api
+
+/**
+ * @hide
+ * */
+abstract class LineEnvConfig {
+    open val apiServerBaseUri = "https://api.line.me/"
+    open val openIdDiscoveryDocumentUrl = "https://access.line.me/.well-known/openid-configuration"
+    open val webLoginPageUrl = "https://access.line.me/oauth2/v2.1/login"
+}

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationConfig.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationConfig.java
@@ -1,5 +1,6 @@
 package com.linecorp.linesdk.auth;
 
+import android.content.Context;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -7,8 +8,12 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.linecorp.linesdk.Constants;
+import com.linecorp.linesdk.ManifestParser;
+import com.linecorp.linesdk.api.LineDefaultEnvConfig;
+import com.linecorp.linesdk.api.LineEnvConfig;
 import com.linecorp.linesdk.utils.ObjectUtils;
 
 /**
@@ -158,15 +163,35 @@ public class LineAuthenticationConfig implements Parcelable {
         private boolean isEncryptorPreparationDisabled;
 
         public Builder(@NonNull String channelId) {
+            this(channelId, (Context) null);
+        }
+
+        public Builder(@NonNull String channelId, @Nullable Context context) {
+            this(channelId, context, new ManifestParser());
+        }
+
+        @VisibleForTesting
+        Builder(@NonNull String channelId, @Nullable Context context, @NonNull ManifestParser parser) {
             if (TextUtils.isEmpty(channelId)) {
                 throw new IllegalArgumentException("channelId is empty.");
             }
             this.channelId = channelId;
-            openidDiscoveryDocumentUrl = Uri.parse(Constants.OPENID_DISCOVERY_DOCUMENT_URL);
-            apiBaseUrl = Uri.parse(Constants.API_SERVER_BASE_URI);
-            webLoginPageUrl = Uri.parse(Constants.WEB_LOGIN_PAGE_URL);
+
+            LineEnvConfig config = null;
+            if (context != null) {
+                config = parser.parse(context);
+            }
+
+            if (config == null) {
+                config = new LineDefaultEnvConfig();
+            }
+
+            openidDiscoveryDocumentUrl = Uri.parse(config.getOpenIdDiscoveryDocumentUrl());
+            apiBaseUrl = Uri.parse(config.getApiServerBaseUri());
+            webLoginPageUrl = Uri.parse(config.getWebLoginPageUrl());
         }
 
+        @Deprecated
         @NonNull
         Builder openidDiscoveryDocumentUrl(@Nullable final Uri openidDiscoveryDocumentUrl) {
             this.openidDiscoveryDocumentUrl =
@@ -175,6 +200,7 @@ public class LineAuthenticationConfig implements Parcelable {
             return this;
         }
 
+        @Deprecated
         @NonNull
         Builder apiBaseUrl(@Nullable final Uri apiBaseUrl) {
             this.apiBaseUrl = ObjectUtils.defaultIfNull(apiBaseUrl,
@@ -182,6 +208,7 @@ public class LineAuthenticationConfig implements Parcelable {
             return this;
         }
 
+        @Deprecated
         @NonNull
         Builder webLoginPageUrl(@Nullable final Uri webLoginPageUrl) {
             this.webLoginPageUrl = ObjectUtils.defaultIfNull(webLoginPageUrl,

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationConfig.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationConfig.java
@@ -10,7 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import com.linecorp.linesdk.Constants;
 import com.linecorp.linesdk.ManifestParser;
 import com.linecorp.linesdk.api.LineDefaultEnvConfig;
 import com.linecorp.linesdk.api.LineEnvConfig;
@@ -196,7 +195,7 @@ public class LineAuthenticationConfig implements Parcelable {
         Builder openidDiscoveryDocumentUrl(@Nullable final Uri openidDiscoveryDocumentUrl) {
             this.openidDiscoveryDocumentUrl =
                     ObjectUtils.defaultIfNull(openidDiscoveryDocumentUrl,
-                                              Uri.parse(Constants.OPENID_DISCOVERY_DOCUMENT_URL));
+                            Uri.parse(new LineDefaultEnvConfig().getOpenIdDiscoveryDocumentUrl()));
             return this;
         }
 
@@ -204,7 +203,7 @@ public class LineAuthenticationConfig implements Parcelable {
         @NonNull
         Builder apiBaseUrl(@Nullable final Uri apiBaseUrl) {
             this.apiBaseUrl = ObjectUtils.defaultIfNull(apiBaseUrl,
-                                                        Uri.parse(Constants.API_SERVER_BASE_URI));
+                    Uri.parse(new LineDefaultEnvConfig().getApiServerBaseUri()));
             return this;
         }
 
@@ -212,7 +211,7 @@ public class LineAuthenticationConfig implements Parcelable {
         @NonNull
         Builder webLoginPageUrl(@Nullable final Uri webLoginPageUrl) {
             this.webLoginPageUrl = ObjectUtils.defaultIfNull(webLoginPageUrl,
-                                                             Uri.parse(Constants.WEB_LOGIN_PAGE_URL));
+                    Uri.parse(new LineDefaultEnvConfig().getWebLoginPageUrl()));
             return this;
         }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationConfig.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationConfig.java
@@ -13,7 +13,6 @@ import androidx.annotation.VisibleForTesting;
 import com.linecorp.linesdk.ManifestParser;
 import com.linecorp.linesdk.api.LineDefaultEnvConfig;
 import com.linecorp.linesdk.api.LineEnvConfig;
-import com.linecorp.linesdk.utils.ObjectUtils;
 
 /**
  * @hide
@@ -193,25 +192,27 @@ public class LineAuthenticationConfig implements Parcelable {
         @Deprecated
         @NonNull
         Builder openidDiscoveryDocumentUrl(@Nullable final Uri openidDiscoveryDocumentUrl) {
-            this.openidDiscoveryDocumentUrl =
-                    ObjectUtils.defaultIfNull(openidDiscoveryDocumentUrl,
-                            Uri.parse(new LineDefaultEnvConfig().getOpenIdDiscoveryDocumentUrl()));
+            if (openidDiscoveryDocumentUrl != null) {
+                this.openidDiscoveryDocumentUrl = openidDiscoveryDocumentUrl;
+            }
             return this;
         }
 
         @Deprecated
         @NonNull
         Builder apiBaseUrl(@Nullable final Uri apiBaseUrl) {
-            this.apiBaseUrl = ObjectUtils.defaultIfNull(apiBaseUrl,
-                    Uri.parse(new LineDefaultEnvConfig().getApiServerBaseUri()));
+            if (apiBaseUrl != null) {
+                this.apiBaseUrl = apiBaseUrl;
+            }
             return this;
         }
 
         @Deprecated
         @NonNull
         Builder webLoginPageUrl(@Nullable final Uri webLoginPageUrl) {
-            this.webLoginPageUrl = ObjectUtils.defaultIfNull(webLoginPageUrl,
-                    Uri.parse(new LineDefaultEnvConfig().getWebLoginPageUrl()));
+            if (webLoginPageUrl != null) {
+                this.webLoginPageUrl = webLoginPageUrl;
+            }
             return this;
         }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/CreateOpenChatActivity.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/CreateOpenChatActivity.kt
@@ -20,6 +20,7 @@ import com.linecorp.linesdk.LineApiError
 import com.linecorp.linesdk.R
 import com.linecorp.linesdk.api.LineApiClient
 import com.linecorp.linesdk.api.LineApiClientBuilder
+import com.linecorp.linesdk.api.LineDefaultEnvConfig
 import com.linecorp.linesdk.auth.internal.LineAppVersion
 import com.linecorp.linesdk.openchat.OpenChatRoomInfo
 import kotlinx.android.synthetic.main.activity_create_open_chat.progressBar
@@ -133,12 +134,13 @@ class CreateOpenChatActivity : AppCompatActivity() {
         const val ARG_ERROR_RESULT: String = "arg_error_result"
         private const val ARG_API_BASE_URL: String = "arg_api_base_url"
         private const val ARG_CHANNEL_ID: String = "arg_channel_id"
+        @Deprecated("The 3rd argument apiBaseUrl will not be supported in the future version.")
         @JvmStatic
         @JvmOverloads
         fun createIntent(
             context: Context,
             channelId: String,
-            apiBaseUrl: String = Constants.API_SERVER_BASE_URI
+            apiBaseUrl: String = LineDefaultEnvConfig().apiServerBaseUri
         ): Intent =
             Intent(context, CreateOpenChatActivity::class.java)
                 .putExtra(ARG_API_BASE_URL, apiBaseUrl)

--- a/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/CreateOpenChatActivity.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/CreateOpenChatActivity.kt
@@ -3,7 +3,6 @@ package com.linecorp.linesdk.openchat.ui
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.View.GONE
 import android.view.View.VISIBLE
@@ -20,7 +19,6 @@ import com.linecorp.linesdk.LineApiError
 import com.linecorp.linesdk.R
 import com.linecorp.linesdk.api.LineApiClient
 import com.linecorp.linesdk.api.LineApiClientBuilder
-import com.linecorp.linesdk.api.LineDefaultEnvConfig
 import com.linecorp.linesdk.auth.internal.LineAppVersion
 import com.linecorp.linesdk.openchat.OpenChatRoomInfo
 import kotlinx.android.synthetic.main.activity_create_open_chat.progressBar
@@ -29,10 +27,8 @@ class CreateOpenChatActivity : AppCompatActivity() {
     private enum class CreateOpenChatStep { ChatroomInfo, UserProfile }
 
     private val lineApiClient: LineApiClient by lazy {
-        val apiBaseUrl = intent.getStringExtra(ARG_API_BASE_URL).orEmpty()
         val channelId = intent.getStringExtra(ARG_CHANNEL_ID).orEmpty()
         LineApiClientBuilder(this, channelId)
-            .apiBaseUri(Uri.parse(apiBaseUrl))
             .build()
     }
 
@@ -132,18 +128,13 @@ class CreateOpenChatActivity : AppCompatActivity() {
     companion object {
         const val ARG_OPEN_CHATROOM_INFO: String = "arg_open_chatroom_info"
         const val ARG_ERROR_RESULT: String = "arg_error_result"
-        private const val ARG_API_BASE_URL: String = "arg_api_base_url"
         private const val ARG_CHANNEL_ID: String = "arg_channel_id"
-        @Deprecated("The 3rd argument apiBaseUrl will not be supported in the future version.")
         @JvmStatic
-        @JvmOverloads
         fun createIntent(
             context: Context,
-            channelId: String,
-            apiBaseUrl: String = LineDefaultEnvConfig().apiServerBaseUri
+            channelId: String
         ): Intent =
             Intent(context, CreateOpenChatActivity::class.java)
-                .putExtra(ARG_API_BASE_URL, apiBaseUrl)
                 .putExtra(ARG_CHANNEL_ID, channelId)
 
         @JvmStatic

--- a/line-sdk/src/test/java/com/linecorp/linesdk/ManifestParserTest.kt
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/ManifestParserTest.kt
@@ -1,0 +1,93 @@
+package com.linecorp.linesdk
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Bundle
+import com.linecorp.linesdk.api.LineEnvConfig
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val MODULE_VALUE = "LineEnvConfig"
+private const val PACKAGE_NAME_SDK_CLIENT = "com.linecorp.linesdktest"
+private const val TEST_API_SERVER_BASE_URI = "https://api-test"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [TestConfig.TARGET_SDK_VERSION])
+internal class ManifestParserTest {
+
+    private class InvalidClass
+
+    private class NewEnvConfig : LineEnvConfig() {
+        override val apiServerBaseUri = TEST_API_SERVER_BASE_URI
+    }
+
+    private val mockContext = mock(Context::class.java)
+
+    private val parser = ManifestParser()
+    private val applicationInfo = ApplicationInfo()
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        `when`(mockContext.packageName).thenReturn(PACKAGE_NAME_SDK_CLIENT)
+
+        val mockPackageManager = mock(PackageManager::class.java)
+        `when`(
+            mockPackageManager.getApplicationInfo(
+                eq(PACKAGE_NAME_SDK_CLIENT),
+                eq(PackageManager.GET_META_DATA)
+            )
+        )
+            .thenReturn(applicationInfo)
+
+        `when`(mockContext.packageManager).thenReturn(mockPackageManager)
+    }
+
+    @Test
+    fun `parse returns NewEnvConfig if it is in metadata`() {
+        applicationInfo.metaData = Bundle().apply {
+            putString(MODULE_VALUE, NewEnvConfig::class.java.name)
+        }
+
+        Assert.assertNotNull(parser.parse(mockContext))
+
+        Assert.assertEquals(
+            NewEnvConfig().apiServerBaseUri,
+            parser.parse(mockContext)!!.apiServerBaseUri
+        )
+    }
+
+    @Test
+    fun `parse returns null if no metadata`() {
+        applicationInfo.metaData = Bundle()
+
+        Assert.assertNull(parser.parse(mockContext))
+    }
+
+    @Test
+    fun `parse returns null if no correct key in metadata`() {
+        applicationInfo.metaData = Bundle().apply {
+            putString("wrong_key", NewEnvConfig::class.java.name)
+        }
+
+        Assert.assertNull(parser.parse(mockContext))
+    }
+
+    @Test
+    fun `parse returns null if no LineEnvConfig is provided in metadata`() {
+        applicationInfo.metaData = Bundle().apply {
+            putString(MODULE_VALUE, InvalidClass::class.java.name)
+        }
+
+        Assert.assertNull(parser.parse(mockContext))
+    }
+
+}


### PR DESCRIPTION
Configure API urls via LineEnvConfig

### Bump lib version to v5.6.2

### API Deprecation

* `LineApiClientBuilder`
  * The `openidDiscoveryDocumentUrl()` and `apiBaseUri()` methods have been deprecated.

* `LineAuthenticationConfig.Builder`
  * The `openidDiscoveryDocumentUrl()`, `apiBaseUrl()` and `webLoginPageUrl()` methods have been deprecated.

