### PR TITLE
add query intent info in AndroidManifest.xml for Android 11

### DIFF
--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group = "com.linecorp.linesdk"
-version = "5.7.1"
+version = "5.7.2"
 
 android {
     compileSdkVersion 30
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 30
-        versionCode 5_07_01
+        versionCode 5_07_02
         versionName version
 
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/line-sdk/src/main/AndroidManifest.xml
+++ b/line-sdk/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 
     <application


### PR DESCRIPTION
## Summary
From Android 11, the query `context.getPackageManager().queryIntentActivities()` may return empty list if the query is not set in AndroidManifest.xml.