### PR TITLE
Remove allowBackup config. Let App decide by itself

### DIFF
--- a/line-sdk/src/main/AndroidManifest.xml
+++ b/line-sdk/src/main/AndroidManifest.xml
@@ -10,9 +10,7 @@
         </intent>
     </queries>
 
-    <application
-        android:allowBackup="false"
-        android:supportsRtl="true">
+    <application android:supportsRtl="true">
         <activity
             android:name=".openchat.ui.CreateOpenChatActivity"
             android:theme="@style/AppTheme.NoActionBar"/>


### PR DESCRIPTION
- Summary
  - SDK should not decide if auto backup or not.
  - Remove allowBackup configuration and leave it to App.
  - This also prevents `tools:replace` tag if App needs to allow backup.

- Reference
  - https://developer.android.com/guide/topics/data/autobackup
  - https://github.com/line/line-sdk-android/issues/131