### PR TITLE
chore: add github action to create tag and release after deployment

### DIFF
--- a/.github/workflows/ossrh.yml
+++ b/.github/workflows/ossrh.yml
@@ -1,6 +1,6 @@
 # https://github.com/line/lich/blob/master/.github/workflows/ossrh.yml
 
-name: Deploy to OSSRH
+name: Deploy To OSSRH And Release With Tag
 
 on:
   workflow_dispatch:
@@ -32,3 +32,41 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.OSSRH_PASSWORD }}
         run: ./gradlew closeAndReleaseRepository --stacktrace
 
+  tag_and_release:
+    name: Create Tag And Release
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Retrieve Version
+        run: |
+          echo "version_name=$(${{github.workspace}}/gradlew -q printVersionName)" >> $GITHUB_OUTPUT
+        id: sdk_version
+
+      - name: Get Version
+        run: |
+          echo "version_name=${{steps.sdk_version.outputs.VERSION_NAME}}"
+
+      - name: Create Tag
+        id: create_tag
+        uses: anothrNick/github-tag-action@1.52.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          CUSTOM_TAG: "v${{steps.sdk_version.outputs.VERSION_NAME}}"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "v${{steps.sdk_version.outputs.VERSION_NAME}}"
+          release_name: "Release ${{steps.sdk_version.outputs.VERSION_NAME}}"
+          draft: false
+          prerelease: false

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -231,6 +231,10 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+task printVersionName {
+    println version
+}
+
 artifacts {
     archives javadocJar
     archives sourcesJar


### PR DESCRIPTION
After OSSRH deployment, it triggers `tag_and_release` job to create tag with latest commit and  release to Github with current tag.

Example (v5.8.0):
<img width=300 src=https://user-images.githubusercontent.com/42765398/205197074-8243606b-8990-43ae-860b-d13517d6ed39.jpg />  <img width=310 src=https://user-images.githubusercontent.com/42765398/205197071-5127928b-4114-427b-bb30-916a4aa61860.jpg />


