### PR TITLE
Fix: sample app line login btn listener not called

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
         viewBinding = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.1"
+        kotlinCompilerExtensionVersion = "1.3.2"
     }
     packagingOptions {
         resources {
@@ -52,20 +52,20 @@ dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1")
-    implementation("androidx.activity:activity-compose:1.5.1")
+    implementation("androidx.activity:activity-compose:1.6.1")
     implementation("androidx.appcompat:appcompat:1.5.1")
-    implementation("androidx.compose.ui:ui:1.2.1")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.2.1")
-    implementation("androidx.compose.material3:material3:1.0.0-beta02")
-    implementation("com.google.android.material:material:1.8.0-alpha01")
+    implementation("androidx.compose.ui:ui:1.3.2")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.3.2")
+    implementation("androidx.compose.material3:material3:1.1.0-alpha03")
+    implementation("com.google.android.material:material:1.8.0-beta01")
     implementation("com.google.accompanist:accompanist-systemuicontroller:0.26.3-beta")
-    implementation("androidx.navigation:navigation-compose:2.5.2")
+    implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation("io.coil-kt:coil-compose:2.2.1")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.2.1")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.2.1")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.2.1")
+    androidTestImplementation("androidx.test.ext:junit:1.1.4")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.3.2")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.3.2")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.3.2")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,10 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = true
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
     compileOptions {

--- a/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
@@ -47,6 +47,7 @@ class MainActivity : ComponentActivity() {
             )
         }
 
+    // A delegate for delegating the login result to the internal login handler of the LineLoginButton.
     private val loginDelegate = LoginDelegate.Factory.create()
 
     private fun handleLoginResult(resultCode: Int, intent: Intent?) {

--- a/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.linecorp.linesdk.LoginDelegate
 import com.linecorp.linesdk.Scope
 import com.linecorp.linesdk.sample.ui.composable.AppBar
 import com.linecorp.linesdk.sample.ui.composable.OperationFailedPopup
@@ -45,6 +46,8 @@ class MainActivity : ComponentActivity() {
                 activityResult.data
             )
         }
+
+    private val loginDelegate = LoginDelegate.Factory.create()
 
     private fun handleLoginResult(resultCode: Int, intent: Intent?) {
         if (resultCode == Activity.RESULT_OK) {
@@ -102,7 +105,7 @@ class MainActivity : ComponentActivity() {
                             if (operationFailedPopupMsg != null) {
                                 OperationFailedPopup(
                                     "${failedToLoginOrLogoutMsgTitle}\n\n" +
-                                        "$operationFailedPopupMsg"
+                                            "$operationFailedPopupMsg"
                                 ) {
                                     loginViewModel.dismissFailedPopup()
                                 }
@@ -112,6 +115,7 @@ class MainActivity : ComponentActivity() {
                                 loginViewModel,
                                 channelId,
                                 scopeList,
+                                loginDelegate,
                                 onLoginButtonPressed = loginResultLauncher::launch
                             )
                         }
@@ -132,7 +136,7 @@ class MainActivity : ComponentActivity() {
         super.onActivityResult(requestCode, resultCode, data)
 
         // In order to receive and process the Activity Result to the `LineLoginButton`.
-        handleLoginResult(resultCode, data)
+        loginDelegate.onActivityResult(requestCode, resultCode, data)
     }
 
     companion object {

--- a/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
@@ -104,9 +104,7 @@ class MainActivity : ComponentActivity() {
                                 channelId = channelId,
                                 scopeList = scopeList,
                                 loginDelegateForLineLoginBtn = loginDelegate,
-                                onSimpleLoginButtonPressed = loginResultLauncher::launch,
-                                onLoginSuccessByLineLoginBtn = loginViewModel::processLoginResult,
-                                onLoginFailureByLineLoginBtn = loginViewModel::processLoginResult
+                                onSimpleLoginButtonPressed = loginResultLauncher::launch
                             )
                         }
                     }

--- a/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
@@ -1,9 +1,7 @@
 package com.linecorp.linesdk.sample
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
@@ -41,7 +39,7 @@ class MainActivity : ComponentActivity() {
 
     private val loginResultLauncher =
         registerForActivityResult(StartActivityForResult()) { activityResult ->
-            handleLoginResult(
+            loginViewModel.processLoginIntent(
                 activityResult.resultCode,
                 activityResult.data
             )
@@ -49,17 +47,6 @@ class MainActivity : ComponentActivity() {
 
     // A delegate for delegating the login result to the internal login handler of the LineLoginButton.
     private val loginDelegate = LoginDelegate.Factory.create()
-
-    private fun handleLoginResult(resultCode: Int, intent: Intent?) {
-        if (resultCode == Activity.RESULT_OK) {
-            intent?.let { loginViewModel.processLoginResultFromIntent(it) }
-        } else {
-            val errorResponseString = intent?.dataString.toString()
-
-            Log.e(TAG, errorResponseString)
-            loginViewModel.showFailedPopupWith(ACTIVITY_RESULT_NOT_OK)
-        }
-    }
 
     @ExperimentalMaterial3Api
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -113,11 +100,13 @@ class MainActivity : ComponentActivity() {
                             }
 
                             LoginButtonGroup(
-                                loginViewModel,
-                                channelId,
-                                scopeList,
-                                loginDelegate,
-                                onLoginButtonPressed = loginResultLauncher::launch
+                                loginViewModel = loginViewModel,
+                                channelId = channelId,
+                                scopeList = scopeList,
+                                loginDelegateForLineLoginBtn = loginDelegate,
+                                onSimpleLoginButtonPressed = loginResultLauncher::launch,
+                                onLoginSuccessByLineLoginBtn = loginViewModel::processLoginResult,
+                                onLoginFailureByLineLoginBtn = loginViewModel::processLoginResult,
                             )
                         }
                     }
@@ -138,10 +127,5 @@ class MainActivity : ComponentActivity() {
 
         // In order to receive and process the Activity Result to the `LineLoginButton`.
         loginDelegate.onActivityResult(requestCode, resultCode, data)
-    }
-
-    companion object {
-        private const val TAG = "MainActivity"
-        private const val ACTIVITY_RESULT_NOT_OK = "Activity ResultCode is not OK"
     }
 }

--- a/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/MainActivity.kt
@@ -93,7 +93,7 @@ class MainActivity : ComponentActivity() {
                             if (operationFailedPopupMsg != null) {
                                 OperationFailedPopup(
                                     "${failedToLoginOrLogoutMsgTitle}\n\n" +
-                                            "$operationFailedPopupMsg"
+                                        "$operationFailedPopupMsg"
                                 ) {
                                     loginViewModel.dismissFailedPopup()
                                 }
@@ -106,7 +106,7 @@ class MainActivity : ComponentActivity() {
                                 loginDelegateForLineLoginBtn = loginDelegate,
                                 onSimpleLoginButtonPressed = loginResultLauncher::launch,
                                 onLoginSuccessByLineLoginBtn = loginViewModel::processLoginResult,
-                                onLoginFailureByLineLoginBtn = loginViewModel::processLoginResult,
+                                onLoginFailureByLineLoginBtn = loginViewModel::processLoginResult
                             )
                         }
                     }

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/AppBar.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/AppBar.kt
@@ -10,9 +10,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallTopAppBar
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -32,17 +32,14 @@ fun AppBar(title: String, modifier: Modifier = Modifier, navController: NavContr
 
     systemUiController.setStatusBarColor(appBarBackgroundColor)
 
-    SmallTopAppBar(
+    TopAppBar(
         title = {
             Text(
                 text = title,
                 fontWeight = FontWeight.Black
             )
         },
-        colors = TopAppBarDefaults.smallTopAppBarColors(
-            containerColor = appBarBackgroundColor,
-            titleContentColor = appBarContentColor
-        ),
+        modifier = modifier,
         navigationIcon = {
             navController?.let { controller ->
                 controller.previousBackStackEntry?.let {
@@ -55,7 +52,10 @@ fun AppBar(title: String, modifier: Modifier = Modifier, navController: NavContr
                 }
             }
         },
-        modifier = modifier
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = appBarBackgroundColor,
+            titleContentColor = appBarContentColor
+        )
     )
 }
 

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
@@ -13,16 +13,17 @@ import com.linecorp.linesdk.widget.LoginButton
 @Composable
 fun LineLoginButton(
     channelId: String,
-    loginDelegate: LoginDelegate,
     modifier: Modifier = Modifier,
-    handleLoginResult: (result: LineLoginResult) -> Unit
+    onLoginSuccess: (result: LineLoginResult) -> Unit = {},
+    onLoginFailure: (result: LineLoginResult) -> Unit = {},
+    loginDelegate: LoginDelegate,
 ) {
     val loginListener = object : LoginListener {
         override fun onLoginSuccess(result: LineLoginResult) =
-            handleLoginResult(result)
+            onLoginSuccess(result)
 
         override fun onLoginFailure(result: LineLoginResult?) =
-            handleLoginResult(result ?: LineLoginResult.internalError("Unknown error"))
+            onLoginFailure(result ?: LineLoginResult.internalError("LineLoginResult is null"))
     }
 
     AndroidView({ LoginButton(it) }, modifier = modifier) { loginButton ->
@@ -42,6 +43,6 @@ private fun LineLoginButtonPreview() {
         LineLoginButton(
             channelId = "1234567",
             loginDelegate = dummyLoginDelegate
-        ) { /** ignored */ }
+        )
     }
 }

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
@@ -13,8 +13,8 @@ import com.linecorp.linesdk.widget.LoginButton
 @Composable
 fun LineLoginButton(
     channelId: String,
+    loginDelegate: LoginDelegate,
     modifier: Modifier = Modifier,
-    loginDelegate: LoginDelegate = LoginDelegate.Factory.create(),
     handleLoginResult: (result: LineLoginResult) -> Unit
 ) {
     val loginListener = object : LoginListener {
@@ -37,7 +37,11 @@ fun LineLoginButton(
 @Preview("LineLoginButtonPreview")
 @Composable
 private fun LineLoginButtonPreview() {
+    val dummyLoginDelegate = LoginDelegate.Factory.create()
     LineSdkAndroidTheme {
-        LineLoginButton(channelId = "1234567") { /** ignored */ }
+        LineLoginButton(
+            channelId = "1234567",
+            loginDelegate = dummyLoginDelegate
+        ) { /** ignored */ }
     }
 }

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
@@ -14,6 +14,7 @@ import com.linecorp.linesdk.widget.LoginButton
 fun LineLoginButton(
     channelId: String,
     modifier: Modifier = Modifier,
+    loginDelegate: LoginDelegate = LoginDelegate.Factory.create(),
     handleLoginResult: (result: LineLoginResult) -> Unit
 ) {
     val loginListener = object : LoginListener {
@@ -25,9 +26,6 @@ fun LineLoginButton(
     }
 
     AndroidView({ LoginButton(it) }, modifier = modifier) { loginButton ->
-        // A delegate for delegating the login result to the internal login handler.
-        val loginDelegate = LoginDelegate.Factory.create()
-
         loginButton.apply {
             setChannelId(channelId)
             setLoginDelegate(loginDelegate)

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
@@ -16,7 +16,7 @@ fun LineLoginButton(
     modifier: Modifier = Modifier,
     onLoginSuccess: (result: LineLoginResult) -> Unit = {},
     onLoginFailure: (result: LineLoginResult) -> Unit = {},
-    loginDelegate: LoginDelegate,
+    loginDelegate: LoginDelegate
 ) {
     val loginListener = object : LoginListener {
         override fun onLoginSuccess(result: LineLoginResult) =

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/LineLoginButton.kt
@@ -14,16 +14,15 @@ import com.linecorp.linesdk.widget.LoginButton
 fun LineLoginButton(
     channelId: String,
     modifier: Modifier = Modifier,
-    onLoginSuccess: (result: LineLoginResult) -> Unit = {},
-    onLoginFailure: (result: LineLoginResult) -> Unit = {},
-    loginDelegate: LoginDelegate
+    loginDelegate: LoginDelegate,
+    handleLoginResult: (LineLoginResult) -> Unit
 ) {
     val loginListener = object : LoginListener {
         override fun onLoginSuccess(result: LineLoginResult) =
-            onLoginSuccess(result)
+            handleLoginResult(result)
 
         override fun onLoginFailure(result: LineLoginResult?) =
-            onLoginFailure(result ?: LineLoginResult.internalError("LineLoginResult is null"))
+            handleLoginResult(result ?: LineLoginResult.internalError("LineLoginResult is null"))
     }
 
     AndroidView({ LoginButton(it) }, modifier = modifier) { loginButton ->
@@ -43,6 +42,6 @@ private fun LineLoginButtonPreview() {
         LineLoginButton(
             channelId = "1234567",
             loginDelegate = dummyLoginDelegate
-        )
+        ) { /** ignored */ }
     }
 }

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/ProfileContent.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/composable/ProfileContent.kt
@@ -117,7 +117,9 @@ private fun ProfileContentLoggedInPreview() {
             LineProfile(
                 "123456789",
                 "This is a Preview",
-                Uri.parse("https://source.android.com/static/docs/setup/images/Android_symbol_green_RGB.png"),
+                Uri.parse(
+                    "https://source.android.com/static/docs/setup/images/Android_symbol_green_RGB.png"
+                ),
                 "Hello World!"
             )
         }

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.linecorp.linesdk.LoginDelegate
 import com.linecorp.linesdk.Scope
 import com.linecorp.linesdk.sample.ApiListActivity
 import com.linecorp.linesdk.sample.ui.composable.ApiDemoButton
@@ -27,6 +28,7 @@ fun LoginButtonGroup(
     loginViewModel: LoginViewModel,
     channelId: String,
     scopeList: List<Scope>,
+    loginDelegate: LoginDelegate,
     onLoginButtonPressed: (Intent) -> Unit
 ) {
     LazyColumn(
@@ -47,7 +49,8 @@ fun LoginButtonGroup(
             LineLoginButton(
                 channelId,
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
+                loginDelegate = loginDelegate
             ) {
                 loginViewModel.processLoginResult(it)
             }

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
@@ -1,11 +1,7 @@
 package com.linecorp.linesdk.sample.ui.homeScreen
 
 import android.content.Intent
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
@@ -1,7 +1,11 @@
 package com.linecorp.linesdk.sample.ui.homeScreen
 
 import android.content.Intent
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -13,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.linecorp.linesdk.LoginDelegate
 import com.linecorp.linesdk.Scope
-import com.linecorp.linesdk.auth.LineLoginResult
 import com.linecorp.linesdk.sample.ApiListActivity
 import com.linecorp.linesdk.sample.ui.composable.ApiDemoButton
 import com.linecorp.linesdk.sample.ui.composable.LineLoginButton
@@ -25,10 +28,8 @@ fun LoginButtonGroup(
     loginViewModel: LoginViewModel,
     channelId: String,
     scopeList: List<Scope>,
-    onSimpleLoginButtonPressed: (Intent) -> Unit,
     loginDelegateForLineLoginBtn: LoginDelegate,
-    onLoginSuccessByLineLoginBtn: (result: LineLoginResult) -> Unit,
-    onLoginFailureByLineLoginBtn: (result: LineLoginResult) -> Unit
+    onSimpleLoginButtonPressed: (Intent) -> Unit
 ) {
     LazyColumn(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -50,8 +51,7 @@ fun LoginButtonGroup(
                 modifier = Modifier
                     .fillMaxWidth(),
                 loginDelegate = loginDelegateForLineLoginBtn,
-                onLoginSuccess = onLoginSuccessByLineLoginBtn,
-                onLoginFailure = onLoginFailureByLineLoginBtn
+                handleLoginResult = loginViewModel::processLoginResult
             )
 
             ApiDemoButton(

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.linecorp.linesdk.LoginDelegate
 import com.linecorp.linesdk.Scope
+import com.linecorp.linesdk.auth.LineLoginResult
 import com.linecorp.linesdk.sample.ApiListActivity
 import com.linecorp.linesdk.sample.ui.composable.ApiDemoButton
 import com.linecorp.linesdk.sample.ui.composable.LineLoginButton
@@ -24,8 +25,10 @@ fun LoginButtonGroup(
     loginViewModel: LoginViewModel,
     channelId: String,
     scopeList: List<Scope>,
-    loginDelegate: LoginDelegate,
-    onLoginButtonPressed: (Intent) -> Unit
+    onSimpleLoginButtonPressed: (Intent) -> Unit,
+    loginDelegateForLineLoginBtn: LoginDelegate,
+    onLoginSuccessByLineLoginBtn: (result: LineLoginResult) -> Unit,
+    onLoginFailureByLineLoginBtn: (result: LineLoginResult) -> Unit,
 ) {
     LazyColumn(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -46,10 +49,10 @@ fun LoginButtonGroup(
                 channelId,
                 modifier = Modifier
                     .fillMaxWidth(),
-                loginDelegate = loginDelegate
-            ) {
-                loginViewModel.processLoginResult(it)
-            }
+                loginDelegate = loginDelegateForLineLoginBtn,
+                onLoginSuccess = onLoginSuccessByLineLoginBtn,
+                onLoginFailure = onLoginFailureByLineLoginBtn
+            )
 
             ApiDemoButton(
                 "login",
@@ -62,7 +65,7 @@ fun LoginButtonGroup(
                     channelId,
                     scopeList
                 )
-                onLoginButtonPressed(intent)
+                onSimpleLoginButtonPressed(intent)
             }
 
             ApiDemoButton(
@@ -77,7 +80,7 @@ fun LoginButtonGroup(
                     scopeList,
                     onlyWebLogin = true
                 )
-                onLoginButtonPressed(intent)
+                onSimpleLoginButtonPressed(intent)
             }
 
             ApiDemoButton(

--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
@@ -28,7 +28,7 @@ fun LoginButtonGroup(
     onSimpleLoginButtonPressed: (Intent) -> Unit,
     loginDelegateForLineLoginBtn: LoginDelegate,
     onLoginSuccessByLineLoginBtn: (result: LineLoginResult) -> Unit,
-    onLoginFailureByLineLoginBtn: (result: LineLoginResult) -> Unit,
+    onLoginFailureByLineLoginBtn: (result: LineLoginResult) -> Unit
 ) {
     LazyColumn(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/linecorp/linesdk/sample/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/viewmodel/LoginViewModel.kt
@@ -12,13 +12,13 @@ import com.linecorp.linesdk.Scope
 import com.linecorp.linesdk.auth.LineAuthenticationParams
 import com.linecorp.linesdk.auth.LineLoginApi
 import com.linecorp.linesdk.auth.LineLoginResult
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Locale
 
 class LoginViewModel(context: Context, channelId: String) :
     LineApiViewModelBase(context, channelId) {

--- a/app/src/main/java/com/linecorp/linesdk/sample/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/viewmodel/LoginViewModel.kt
@@ -80,20 +80,21 @@ class LoginViewModel(context: Context, channelId: String) :
         _userProfileFlow.update { lineProfile }
     }
 
-    fun processLoginIntent(resultCode: Int, nullableIntent: Intent?) =
-        nullableIntent?.let { intent ->
-            if (!isResultCodeOk(resultCode)) {
-                processFailureMsg("resultCode is not OK.", "resultCode = $resultCode")
-                intent.dataString?.let { processFailureMsg(it) }
-                return
-            }
-
-            val loginResult = LineLoginApi.getLoginResultFromIntent(intent)
-            processLoginResult(loginResult)
-
-        } ?: run {
-            processFailureMsg("Login intent is null")
+    fun processLoginIntent(resultCode: Int, intent: Intent?) {
+        if (!isResultCodeOk(resultCode)) {
+            val errorMessage = intent?.dataString ?: "login error but no error message"
+            processFailureMsg(errorMessage)
+            return
         }
+
+        if (intent == null) {
+            processFailureMsg("success but no intent")
+            return
+        }
+
+        val loginResult = LineLoginApi.getLoginResultFromIntent(intent)
+        processLoginResult(loginResult)
+    }
 
     fun logout() {
         viewModelScope.launch {

--- a/dependencyVersion.gradle
+++ b/dependencyVersion.gradle
@@ -1,11 +1,11 @@
 ext {
     // version for dependencies
     ver = [
-            kotlin      : "1.7.10",
+            kotlin      : "1.7.20",
 
             // build tools
             buildTools  : [
-                    android_gradle : "7.3.0",
+                    android_gradle : "7.3.1",
                     bintray_gradle: "1.8.5",
                     maven_gradle: "2.1"
             ],

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Sep 20 18:41:05 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
We have found that the LINE login button (`LineLoginButton`) used in the sample app did not successfully register a login result callback listener. Therefore, this PR fixed this issue and also made some minor adjustments to other content.

To solve the issue of `loginListener`'s `onLoginSuccess` and `onLoginFailure` not being called after login, we used the `LoginDelegate` provided by the SDK itself. Specifically, we passed the login activity's `Intent` and its relative params to `LineLoginButton` by calling `loginDelegate.onActivityResult(...)`, allowing it to internally call the registered `loginListener`. For more information about `LoginDelegate`, please go to [here](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/#use-button).

In addition to this change, we also adjusted some of the other code in the sample app, such as the view model, to reflect these changes.

The minimum kotlin version of SDK has been upgraded to `1.7.20`, and the gradle has been upgraded to `7.6`.