### PR TITLE
Refine access denied server error handling

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run Unit Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
 
   lib:
     name: Generate SDK library
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/line-sdk/src/main/java/com/linecorp/linesdk/LineApiResponseCode.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/LineApiResponseCode.java
@@ -21,6 +21,10 @@ public enum LineApiResponseCode {
      */
     SERVER_ERROR,
     /**
+     * User denied to grant permissions.
+     */
+    ACCESS_DENIED,
+    /**
      * An authentication agent error occurred.
      */
     AUTHENTICATION_AGENT_ERROR,

--- a/line-sdk/src/main/java/com/linecorp/linesdk/LineApiResponseCode.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/LineApiResponseCode.java
@@ -21,10 +21,6 @@ public enum LineApiResponseCode {
      */
     SERVER_ERROR,
     /**
-     * User denied to grant permissions.
-     */
-    ACCESS_DENIED,
-    /**
      * An authentication agent error occurred.
      */
     AUTHENTICATION_AGENT_ERROR,

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -370,7 +370,7 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
             return !TextUtils.isEmpty(requestToken);
         }
 
-        boolean isAccessDeniedError() {
+        boolean isUserDeniedPermission() {
             return LineApiResponseCode.ACCESS_DENIED.toString().equalsIgnoreCase(serverErrorCode);
         }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -301,7 +301,7 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
 
         return !TextUtils.isEmpty(requestToken)
                ? Result.createAsSuccess(requestToken, friendshipStatusChanged)
-               : Result.createAsAuthenticationAgentError(
+               : Result.createAsAuthenticationError(
                 resultDataUri.getQueryParameter("error"),
                 resultDataUri.getQueryParameter("error_description"));
     }
@@ -344,7 +344,7 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
 
         @VisibleForTesting
         @NonNull
-        static Result createAsAuthenticationAgentError(
+        static Result createAsAuthenticationError(
                 @NonNull String error, @NonNull String errorDescription) {
             return new Result(
                     null /* requestToken */,

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -12,9 +12,16 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.core.content.ContextCompat;
+
 import com.linecorp.linesdk.BuildConfig;
 import com.linecorp.linesdk.Constants;
 import com.linecorp.linesdk.LineApiError;
+import com.linecorp.linesdk.LineApiResponseCode;
 import com.linecorp.linesdk.Scope;
 import com.linecorp.linesdk.auth.LineAuthenticationConfig;
 import com.linecorp.linesdk.auth.LineAuthenticationParams;
@@ -28,12 +35,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.core.content.ContextCompat;
 
 import static com.linecorp.linesdk.utils.StringUtils.createRandomAlphaNumeric;
 import static com.linecorp.linesdk.utils.UriUtils.appendQueryParams;
@@ -367,6 +368,10 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
 
         boolean isSuccess() {
             return !TextUtils.isEmpty(requestToken);
+        }
+
+        boolean isAccessDeniedError() {
+            return LineApiResponseCode.ACCESS_DENIED.toString().equalsIgnoreCase(serverErrorCode);
         }
 
         boolean isAuthenticationAgentError() {

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -21,7 +21,6 @@ import androidx.core.content.ContextCompat;
 import com.linecorp.linesdk.BuildConfig;
 import com.linecorp.linesdk.Constants;
 import com.linecorp.linesdk.LineApiError;
-import com.linecorp.linesdk.LineApiResponseCode;
 import com.linecorp.linesdk.Scope;
 import com.linecorp.linesdk.auth.LineAuthenticationConfig;
 import com.linecorp.linesdk.auth.LineAuthenticationParams;
@@ -307,6 +306,8 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
     }
 
     /* package */ static class Result {
+        /* package */ static final String USER_DENIED_PERMISSION_ERROR_CODE = "ACCESS_DENIED";
+
         @Nullable
         private final String requestToken;
         @Nullable
@@ -371,7 +372,7 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
         }
 
         boolean isUserDeniedPermission() {
-            return LineApiResponseCode.ACCESS_DENIED.toString().equalsIgnoreCase(serverErrorCode);
+            return USER_DENIED_PERMISSION_ERROR_CODE.equalsIgnoreCase(serverErrorCode);
         }
 
         boolean isAuthenticationAgentError() {

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
@@ -149,7 +149,7 @@ import androidx.annotation.VisibleForTesting;
 
     private static LineLoginResult getLoginErrorResult(BrowserAuthenticationApi.Result authResult) {
         LineLoginResult errorResult;
-        if (authResult.isAccessDeniedError()) {
+        if (authResult.isUserDeniedPermission()) {
             errorResult = LineLoginResult.canceledError();
         } else if (authResult.isAuthenticationAgentError()) {
             errorResult = LineLoginResult.authenticationAgentError(authResult.getLineApiError());

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/LineAuthenticationController.java
@@ -140,14 +140,23 @@ import androidx.annotation.VisibleForTesting;
                 browserAuthenticationApi.getAuthenticationResultFrom(intent);
         if (!authResult.isSuccess()) {
             authenticationStatus.authenticationIntentHandled();
-            final LineLoginResult errorResult =
-                    authResult.isAuthenticationAgentError()
-                    ? LineLoginResult.authenticationAgentError(authResult.getLineApiError())
-                    : LineLoginResult.internalError(authResult.getLineApiError());
+            final LineLoginResult errorResult = getLoginErrorResult(authResult);
             activity.onAuthenticationFinished(errorResult);
             return;
         }
         new AccessTokenRequestTask().execute(authResult);
+    }
+
+    private static LineLoginResult getLoginErrorResult(BrowserAuthenticationApi.Result authResult) {
+        LineLoginResult errorResult;
+        if (authResult.isAccessDeniedError()) {
+            errorResult = LineLoginResult.canceledError();
+        } else if (authResult.isAuthenticationAgentError()) {
+            errorResult = LineLoginResult.authenticationAgentError(authResult.getLineApiError());
+        } else {
+            errorResult = LineLoginResult.internalError(authResult.getLineApiError());
+        }
+        return errorResult;
     }
 
     @MainThread

--- a/line-sdk/src/test/java/com/linecorp/linesdk/auth/internal/LineAuthenticationControllerTest.java
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/auth/internal/LineAuthenticationControllerTest.java
@@ -234,7 +234,7 @@ public class LineAuthenticationControllerTest {
     public void testAccessDeniedErrorOfGettingAccessToken() throws Exception {
         Intent newIntentData = new Intent();
         doReturn(BrowserAuthenticationApi.Result.createAsAuthenticationError(
-                LineApiResponseCode.ACCESS_DENIED.toString(),
+                BrowserAuthenticationApi.Result.USER_DENIED_PERMISSION_ERROR_CODE,
                 ""))
                 .when(browserAuthenticationApi)
                 .getAuthenticationResultFrom(newIntentData);

--- a/line-sdk/src/test/java/com/linecorp/linesdk/auth/internal/LineAuthenticationControllerTest.java
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/auth/internal/LineAuthenticationControllerTest.java
@@ -85,7 +85,7 @@ public class LineAuthenticationControllerTest {
             .nonce(NONCE)
             .build();
 
-    private static final Scope[] SCOPE_ARRAY = { Scope.PROFILE, Scope.FRIEND, Scope.GROUP };
+    private static final Scope[] SCOPE_ARRAY = {Scope.PROFILE, Scope.FRIEND, Scope.GROUP};
     private static final List<Scope> SCOPE_LIST = Arrays.asList(SCOPE_ARRAY);
 
     private static final LineAuthenticationParams LINE_AUTH_PARAMS =
@@ -141,7 +141,7 @@ public class LineAuthenticationControllerTest {
                 accessTokenCache,
                 authenticationStatus,
                 LINE_AUTH_PARAMS);
-        target =  Mockito.spy(controller);
+        target = Mockito.spy(controller);
         doReturn(PKCE_CODE).when(target).createPKCECode();
 
         doReturn(RuntimeEnvironment.application).when(activity).getApplicationContext();
@@ -228,6 +228,28 @@ public class LineAuthenticationControllerTest {
 
         verify(activity, times(1)).onAuthenticationFinished(
                 LineLoginResult.error(LineApiResponseCode.INTERNAL_ERROR, LineApiError.DEFAULT));
+    }
+
+    @Test
+    public void testAccessDeniedErrorOfGettingAccessToken() throws Exception {
+        Intent newIntentData = new Intent();
+        doReturn(BrowserAuthenticationApi.Result.createAsAuthenticationAgentError(
+                LineApiResponseCode.ACCESS_DENIED.toString(),
+                ""))
+                .when(browserAuthenticationApi)
+                .getAuthenticationResultFrom(newIntentData);
+
+        target.startLineAuthentication();
+
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        Robolectric.getForegroundThreadScheduler().runOneTask();
+
+        verify(browserAuthenticationApi, times(1))
+                .getRequest(activity, config, PKCE_CODE, LINE_AUTH_PARAMS);
+
+        target.handleIntentFromLineApp(newIntentData);
+
+        verify(activity, times(1)).onAuthenticationFinished(LineLoginResult.canceledError());
     }
 
     @Test

--- a/line-sdk/src/test/java/com/linecorp/linesdk/auth/internal/LineAuthenticationControllerTest.java
+++ b/line-sdk/src/test/java/com/linecorp/linesdk/auth/internal/LineAuthenticationControllerTest.java
@@ -233,7 +233,7 @@ public class LineAuthenticationControllerTest {
     @Test
     public void testAccessDeniedErrorOfGettingAccessToken() throws Exception {
         Intent newIntentData = new Intent();
-        doReturn(BrowserAuthenticationApi.Result.createAsAuthenticationAgentError(
+        doReturn(BrowserAuthenticationApi.Result.createAsAuthenticationError(
                 LineApiResponseCode.ACCESS_DENIED.toString(),
                 ""))
                 .when(browserAuthenticationApi)


### PR DESCRIPTION
Refine the access denied server error handling. The server error occurred when user denied to grant the permissions, so it should be passed to client side as `CANCEL` error result instead of `AUTHENTICATION_AGENT_ERROR`.


| AS-IS | TO-BE | 
| --- | --- | 
| ![login-cancel-authentication-agent-error](https://github.com/line/line-sdk-android/assets/7045016/a616c717-f6ba-412f-a15f-d48f8b44ba4c) | ![login-cancel-canceled-error](https://github.com/line/line-sdk-android/assets/7045016/4f8c064c-8024-4c51-8e42-34173f9788d7) |

