### PR TITLE
feat. add optional auth parameter

### DIFF
--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
@@ -64,11 +64,19 @@ public class LineAuthenticationParams implements Parcelable {
     @Nullable
     private final Locale uiLocale;
 
+    /**
+     * OPTIONAL. <br></br>
+     * Not yet public available.
+     */
+    @Nullable
+    private final String promptBotID;
+
     private LineAuthenticationParams(final Builder builder) {
         scopes = builder.scopes;
         nonce = builder.nonce;
         botPrompt = builder.botPrompt;
         uiLocale = builder.uiLocale;
+        promptBotID = builder.promptBotID;
     }
 
     private LineAuthenticationParams(@NonNull final Parcel in) {
@@ -76,6 +84,7 @@ public class LineAuthenticationParams implements Parcelable {
         nonce = in.readString();
         botPrompt = readEnum(in, BotPrompt.class);
         uiLocale = (Locale) in.readSerializable();
+        promptBotID = in.readString();
     }
 
     /**
@@ -89,6 +98,7 @@ public class LineAuthenticationParams implements Parcelable {
         dest.writeString(nonce);
         writeEnum(dest, botPrompt);
         dest.writeSerializable(uiLocale);
+        dest.writeString(promptBotID);
     }
 
     /**
@@ -138,6 +148,15 @@ public class LineAuthenticationParams implements Parcelable {
     }
 
     /**
+     * Gets the Prompt Bot Id.
+     * @return the ID of prompt bot
+     */
+    @Nullable
+    public String getPromptBotID() {
+        return promptBotID;
+    }
+
+    /**
      * Represents an option to determine how to prompt the user to add a bot as a friend during the
      * login process.
      */
@@ -162,6 +181,8 @@ public class LineAuthenticationParams implements Parcelable {
         private String nonce;
         private BotPrompt botPrompt;
         private Locale uiLocale;
+
+        private String promptBotID;
 
         public Builder() {}
 
@@ -204,6 +225,11 @@ public class LineAuthenticationParams implements Parcelable {
          */
         public Builder uiLocale(final Locale val) {
             uiLocale = val;
+            return this;
+        }
+
+        public Builder promptBotID(final String botID) {
+            promptBotID = botID;
             return this;
         }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
@@ -66,7 +66,6 @@ public class LineAuthenticationParams implements Parcelable {
 
     /**
      * OPTIONAL. <br></br>
-     * Not yet public available.
      */
     @Nullable
     private final String promptBotID;

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -166,6 +166,9 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
         if (params.getBotPrompt() != null) {
             returnQueryParams.put("bot_prompt", params.getBotPrompt().name().toLowerCase());
         }
+        if (params.getPromptBotID() != null) {
+            returnQueryParams.put("prompt_bot_id", params.getPromptBotID());
+        }
 
         final String returnUri = appendQueryParams(baseReturnUri, returnQueryParams)
                 .toString();


### PR DESCRIPTION
This added the promptBotID parameter to login flow. It allows users to append a linked bot ID to the login URL as query when performing login. For now, this is an internal-only feature so we do not contain any doc or description to it.


- refer to iOS SDK PR: https://github.com/line/line-sdk-ios-swift/pull/188