### PR TITLE
Remove deprecated dependency: `androidx.lifecycle:lifecycle-extensions`

### DIFF
--- a/dependencyVersion.gradle
+++ b/dependencyVersion.gradle
@@ -20,7 +20,7 @@ ext {
                     core            : "1.2.0",
                     exifinterface   : "1.2.0",
                     legacy          : "1.0.0",
-                    lifecycle       : "2.2.0",
+                    lifecycle       : "2.4.0",
                     multidex        : "2.0.1",
 
                     test            : "1.2.0",

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     implementation "androidx.core:core-ktx:${ver.androidx.core}"
     implementation "androidx.exifinterface:exifinterface:${ver.androidx.exifinterface}"
     implementation "androidx.legacy:legacy-support-v4:${ver.androidx.legacy}"
-    implementation "androidx.lifecycle:lifecycle-extensions:${ver.androidx.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:${ver.androidx.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${ver.androidx.lifecycle}"
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/CreateOpenChatActivity.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/CreateOpenChatActivity.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
 import com.linecorp.linesdk.ActionResult
 import com.linecorp.linesdk.Constants
 import com.linecorp.linesdk.LineApiError
@@ -52,7 +51,7 @@ class CreateOpenChatActivity : AppCompatActivity() {
 
     private fun initViewModel() {
         val sharedPreferences = getSharedPreferences("openchat", Context.MODE_PRIVATE)
-        viewModel = ViewModelProviders.of(
+        viewModel = ViewModelProvider(
             this,
             object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/OpenChatInfoFragment.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/OpenChatInfoFragment.kt
@@ -8,7 +8,7 @@ import androidx.annotation.IntegerRes
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.linecorp.linesdk.R
 import com.linecorp.linesdk.databinding.OpenChatInfoFragmentBinding
 import com.linecorp.linesdk.openchat.addAfterTextChangedAction
@@ -51,7 +51,7 @@ class OpenChatInfoFragment : Fragment() {
     }
 
     private fun setupViewModel() {
-        viewModel = ViewModelProviders.of(requireActivity()).get(OpenChatInfoViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity()).get(OpenChatInfoViewModel::class.java)
         binding.viewModel = viewModel
 
         viewModel.chatroomName.observe(this, Observer { name ->

--- a/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/ProfileInfoFragment.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/openchat/ui/ProfileInfoFragment.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.linecorp.linesdk.R
 import com.linecorp.linesdk.databinding.ProfileInfoFragmentBinding
 import com.linecorp.linesdk.openchat.addAfterTextChangedAction
@@ -41,7 +41,7 @@ class ProfileInfoFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        viewModel = ViewModelProviders.of(requireActivity()).get(OpenChatInfoViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity()).get(OpenChatInfoViewModel::class.java)
         binding.viewModel = viewModel
 
         setupViews()


### PR DESCRIPTION
### Description

1. Remove deprecated dependency: `androidx.lifecycle:lifecycle-extensions`
The last version of it is `v2.2.0`
https://mvnrepository.com/artifact/androidx.lifecycle/lifecycle-extensions

2. Quoted from [lifecycle_documents]:

> The APIs in lifecycle-extensions have been deprecated. Instead, add dependencies for the specific Lifecycle artifacts you need.

3. Deprecated `lifecycle-extensions` dependency led to issue: https://github.com/line/flutter_line_sdk/issues/93

4. Bump the version of `lifecycle-viewmodel-ktx` from `2.2.0` to `2.4.0` because of the "Duplicate class issue" when rebuilding the project:
```
> Task :line-sdk:checkDebugAndroidTestDuplicateClasses FAILED
Duplicate class ViewModelLazy found in modules jetified-lifecycle-viewmodel-ktx-2.2.0-runtime and lifecycle-viewmodel-2.4.0-runtime
```

In the LINE SDK v5.10.0, it already implicitly uses "v2.4.0" of `lifecycle` libraries. the "v2.4.0" dependency is from databinding:7.3.1
```
./gradlew line-sdk:dependencies

+--- androidx.databinding:databinding-ktx:7.3.1
|    +--- androidx.lifecycle:lifecycle-runtime-ktx:2.4.0
|    +--- androidx.lifecycle:lifecycle-livedata:2.4.0
```

[lifecycle_documents]: https://developer.android.com/jetpack/androidx/releases/lifecycle

