### PR TITLE
Bump LINE SDK version in sample app to v5.10.1

### DIFF
--- a/.github/workflows/ossrh.yml
+++ b/.github/workflows/ossrh.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Decode Token To File
         uses: timheuer/base64-to-file@v1.2
         with:
-            fileName: 'verification.properties'
-            fileDir: './line-sdk/src/main/resources/META-INF/com/linecorp/linesdk/linesdk/'
-            encodedString: ${{ secrets.SDK_CONSOLE_TOKEN }}
+          fileName: 'verification.properties'
+          fileDir: './line-sdk/src/main/resources/META-INF/com/linecorp/linesdk/linesdk/'
+          encodedString: ${{ secrets.SDK_CONSOLE_TOKEN }}
       - name: Deploy artifacts
         env:
           ORG_GRADLE_PROJECT_repositoryUsername: ${{ secrets.OSSRH_USERNAME }}
@@ -51,12 +51,17 @@ jobs:
 
       - name: Retrieve Version
         run: |
-          echo "version_name=$(${{github.workspace}}/gradlew -q printVersionName)" >> $GITHUB_OUTPUT
+          version_output=$(${{github.workspace}}/gradlew -q printVersionName)
+
+          # Use awk to extract the last line from the output
+          # 'END{print line}' prints the last stored line after processing all input lines
+          VERSION_NAME=$(echo "$version_output" | awk '/./{line=$0} END{print line}')
+          echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_OUTPUT
         id: sdk_version
 
       - name: Get Version
         run: |
-          echo "version_name=${{steps.sdk_version.outputs.VERSION_NAME}}"
+          echo "VERSION_NAME=${{steps.sdk_version.outputs.VERSION_NAME}}"
 
       - name: Create Tag
         id: create_tag

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 }
 
 dependencies {
-    implementation("com.linecorp.linesdk:linesdk:5.9.1")
+    implementation("com.linecorp.linesdk:linesdk:5.10.1")
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1")


### PR DESCRIPTION
1. improve version extraction in GitHub Actions 
1. bump the LINE SDK version used in sample app to v5.10.1