### PR TITLE
Add a parameter for setting initialWebAuthenticationMethod

### DIFF
--- a/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/ui/homeScreen/LoginButtonGroup.kt
@@ -1,16 +1,23 @@
 package com.linecorp.linesdk.sample.ui.homeScreen
 
 import android.content.Intent
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,6 +38,9 @@ fun LoginButtonGroup(
     loginDelegateForLineLoginBtn: LoginDelegate,
     onSimpleLoginButtonPressed: (Intent) -> Unit
 ) {
+    var forceWebLogin by rememberSaveable { mutableStateOf(false) }
+    var qrCodeLogin by rememberSaveable { mutableStateOf(false) }
+
     LazyColumn(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -57,31 +67,31 @@ fun LoginButtonGroup(
             ApiDemoButton(
                 "login",
                 modifier = Modifier
-                    .fillMaxWidth(),
-                enabled = !isLogin
-            ) {
-                val intent = loginViewModel.createLoginIntent(
-                    context,
-                    channelId,
-                    scopeList
-                )
-                onSimpleLoginButtonPressed(intent)
-            }
-
-            ApiDemoButton(
-                "web login",
-                modifier = Modifier
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
                 enabled = !isLogin
             ) {
                 val intent = loginViewModel.createLoginIntent(
                     context,
                     channelId,
                     scopeList,
-                    onlyWebLogin = true
+                    forceWebLogin = forceWebLogin,
+                    qrCodeLogin = qrCodeLogin
                 )
                 onSimpleLoginButtonPressed(intent)
             }
+
+            LabeledCheckbox(
+                label = "Force web login",
+                checked = forceWebLogin,
+                onCheckedChange = { forceWebLogin = it }
+            )
+
+            LabeledCheckbox(
+                label = "QR code login",
+                checked = qrCodeLogin,
+                onCheckedChange = { qrCodeLogin = it }
+            )
 
             ApiDemoButton(
                 "logout",
@@ -102,5 +112,21 @@ fun LoginButtonGroup(
                 ApiListActivity.start(context)
             }
         }
+    }
+}
+
+@Composable
+fun LabeledCheckbox(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange
+        )
+        Text(text = label)
     }
 }

--- a/app/src/main/java/com/linecorp/linesdk/sample/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/linecorp/linesdk/sample/viewmodel/LoginViewModel.kt
@@ -10,6 +10,9 @@ import androidx.lifecycle.viewModelScope
 import com.linecorp.linesdk.LineProfile
 import com.linecorp.linesdk.Scope
 import com.linecorp.linesdk.auth.LineAuthenticationParams
+import com.linecorp.linesdk.auth.LineAuthenticationParams.WebAuthenticationMethod
+import com.linecorp.linesdk.auth.LineAuthenticationParams.WebAuthenticationMethod.email
+import com.linecorp.linesdk.auth.LineAuthenticationParams.WebAuthenticationMethod.qrCode
 import com.linecorp.linesdk.auth.LineLoginApi
 import com.linecorp.linesdk.auth.LineLoginResult
 import java.util.Locale
@@ -46,11 +49,18 @@ class LoginViewModel(context: Context, channelId: String) :
         nonce: String? = null,
         botPrompt: LineAuthenticationParams.BotPrompt? = null,
         uiLocale: Locale? = null,
-        onlyWebLogin: Boolean = false
+        forceWebLogin: Boolean = false,
+        qrCodeLogin: Boolean = false
     ): Intent {
-        val loginAuthParam = createLoginAuthParam(scopes, nonce, botPrompt, uiLocale)
+        val loginAuthParam = createLoginAuthParam(
+            scopes,
+            nonce,
+            botPrompt,
+            uiLocale,
+            webAuthMethod = if (qrCodeLogin) qrCode else email
+        )
 
-        return if (onlyWebLogin) {
+        return if (forceWebLogin) {
             LineLoginApi.getLoginIntentWithoutLineAppAuth(
                 context,
                 channelId,
@@ -119,12 +129,14 @@ class LoginViewModel(context: Context, channelId: String) :
         scopes: List<Scope>,
         nonce: String?,
         botPrompt: LineAuthenticationParams.BotPrompt?,
-        uiLocale: Locale?
+        uiLocale: Locale?,
+        webAuthMethod: WebAuthenticationMethod
     ): LineAuthenticationParams = LineAuthenticationParams.Builder()
         .scopes(scopes)
         .nonce(nonce)
         .uiLocale(uiLocale)
         .botPrompt(botPrompt)
+        .initialWebAuthenticationMethod(webAuthMethod)
         .build()
 
     private fun fetchAndUpdateUserProfile() {

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/LineAuthenticationParams.java
@@ -70,12 +70,20 @@ public class LineAuthenticationParams implements Parcelable {
     @Nullable
     private final String promptBotID;
 
+    /**
+     * OPTIONAL. <br></br>
+     * The initial web authentication method to be used when starting the login process.
+     */
+    @Nullable
+    private final WebAuthenticationMethod webAuthMethod;
+
     private LineAuthenticationParams(final Builder builder) {
         scopes = builder.scopes;
         nonce = builder.nonce;
         botPrompt = builder.botPrompt;
         uiLocale = builder.uiLocale;
         promptBotID = builder.promptBotID;
+        webAuthMethod = builder.webAuthMethod;
     }
 
     private LineAuthenticationParams(@NonNull final Parcel in) {
@@ -84,6 +92,7 @@ public class LineAuthenticationParams implements Parcelable {
         botPrompt = readEnum(in, BotPrompt.class);
         uiLocale = (Locale) in.readSerializable();
         promptBotID = in.readString();
+        webAuthMethod = readEnum(in, WebAuthenticationMethod.class);
     }
 
     /**
@@ -98,6 +107,7 @@ public class LineAuthenticationParams implements Parcelable {
         writeEnum(dest, botPrompt);
         dest.writeSerializable(uiLocale);
         dest.writeString(promptBotID);
+        writeEnum(dest, webAuthMethod);
     }
 
     /**
@@ -155,6 +165,11 @@ public class LineAuthenticationParams implements Parcelable {
         return promptBotID;
     }
 
+    @Nullable
+    public WebAuthenticationMethod getInitialWebAuthenticationMethod() {
+        return webAuthMethod;
+    }
+
     /**
      * Represents an option to determine how to prompt the user to add a LINE Official Account
      * as a friend during the login process.
@@ -173,6 +188,14 @@ public class LineAuthenticationParams implements Parcelable {
     }
 
     /**
+     * The method used for the authentication when using the web authentication flow.
+     */
+    public enum WebAuthenticationMethod {
+        email,
+        qrCode
+    }
+
+    /**
      * Represents a builder to construct LineAuthenticationParams objects.
      */
     public static final class Builder {
@@ -180,8 +203,8 @@ public class LineAuthenticationParams implements Parcelable {
         private String nonce;
         private BotPrompt botPrompt;
         private Locale uiLocale;
-
         private String promptBotID;
+        private WebAuthenticationMethod webAuthMethod;
 
         public Builder() {}
 
@@ -229,6 +252,14 @@ public class LineAuthenticationParams implements Parcelable {
 
         public Builder promptBotID(final String botID) {
             promptBotID = botID;
+            return this;
+        }
+
+        /**
+         * Specifies the initial web authentication method to be used when starting the login process.
+         */
+        public Builder initialWebAuthenticationMethod(final WebAuthenticationMethod method) {
+            webAuthMethod = method;
             return this;
         }
 

--- a/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/auth/internal/BrowserAuthenticationApi.java
@@ -24,6 +24,7 @@ import com.linecorp.linesdk.LineApiError;
 import com.linecorp.linesdk.Scope;
 import com.linecorp.linesdk.auth.LineAuthenticationConfig;
 import com.linecorp.linesdk.auth.LineAuthenticationParams;
+import com.linecorp.linesdk.auth.LineAuthenticationParams.WebAuthenticationMethod;
 import com.linecorp.linesdk.internal.pkce.CodeChallengeMethod;
 import com.linecorp.linesdk.internal.pkce.PKCECode;
 
@@ -180,7 +181,17 @@ import static com.linecorp.linesdk.utils.UriUtils.buildParams;
         if (params.getUILocale() != null) {
             loginQueryParams.put("ui_locales", params.getUILocale().toString());
         }
-        return appendQueryParams(config.getWebLoginPageUrl(), loginQueryParams);
+
+        Uri loginPageUrl = config.getWebLoginPageUrl();
+        Uri.Builder urlBuilder = loginPageUrl.buildUpon();
+        if (params.getInitialWebAuthenticationMethod() == WebAuthenticationMethod.qrCode) {
+            if (loginPageUrl.getFragment() != null)  {
+                throw new AssertionError("Multiple fragment is not yet supported. Require review or report to developer.");
+            }
+            urlBuilder.encodedFragment("/qr");
+        }
+
+        return appendQueryParams(urlBuilder, loginQueryParams).build();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Using this setting, users can specify which auth method (email&password or QR code) should be preferred as the first screen when performing web login.

Sample usage:
```kotlin
val loginAuthParam = LineAuthenticationParams.Builder()
    .initialWebAuthenticationMethod( ... )
    .build()

val intent = LineLoginApi.getLoginIntent(
    context,
    channelId,
    loginAuthParam
)
```

By default, `email` is used to keep the current behavior unchanged.
