### PR TITLE
Migrate publishing to Sonatype Central and upgrade nexus-staging-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:${ver.buildTools.android_gradle}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${ver.kotlin}"
-        classpath "org.jetbrains.kotlin:kotlin-android-extensions:${ver.kotlin}"
-        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
     }
 }
 

--- a/line-sdk/build.gradle
+++ b/line-sdk/build.gradle
@@ -282,8 +282,8 @@ afterEvaluate {
             maven {
                 name = "sonatype"
 
-                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
                 url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
                 def name = findProperty('repositoryUsername') ?: ''
@@ -307,11 +307,9 @@ afterEvaluate {
 
 nexusStaging {
     packageGroup = 'com.linecorp'
+    serverUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/'
     def name = findProperty('nexusUsername') ?: ''
     def pw = findProperty('nexusPassword') ?: ''
     username = name
     password = pw
 }
-
-
-


### PR DESCRIPTION
- Upgrade gradle-nexus-staging-plugin from 0.22.0 to 0.30.0
- Migrate from legacy OSSRH to Sonatype Central Portal
- Update repository URLs to use ossrh-staging-api.central.sonatype.com
- Add explicit serverUrl configuration for nexusStaging

This migration is required as Sonatype OSSRH reached end-of-life on June 30, 2025.

https://central.sonatype.org/pages/ossrh-eol/

Plugin:
- https://github.com/Codearte/gradle-nexus-staging-plugin