### PR TITLE
fix: Add KeyStore fallback for SECURE_HW_COMMUNICATION_FAILED and related errors

### DIFF
--- a/line-sdk/src/main/java/com/linecorp/linesdk/internal/security/encryption/StringAesCipher.kt
+++ b/line-sdk/src/main/java/com/linecorp/linesdk/internal/security/encryption/StringAesCipher.kt
@@ -1,24 +1,40 @@
 package com.linecorp.linesdk.internal.security.encryption
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import android.provider.Settings
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.security.keystore.KeyProperties.PURPOSE_DECRYPT
 import android.security.keystore.KeyProperties.PURPOSE_ENCRYPT
 import android.security.keystore.KeyProperties.PURPOSE_SIGN
 import android.security.keystore.KeyProperties.PURPOSE_VERIFY
+import android.util.Base64
 import java.security.KeyStore
 import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.spec.KeySpec
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.Mac
 import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
 
 /**
- * AES cipher by AndroidKeyStore
+ * AES cipher by AndroidKeyStore with software fallback.
+ *
+ * When Android KeyStore fails (e.g. SECURE_HW_COMMUNICATION_FAILED on some devices),
+ * falls back to PBKDF2-derived software keys to ensure the encryption flow continues.
+ *
+ * @see <a href="https://issuetracker.google.com/issues/229764028">Android KeyStore issues</a>
  */
 class StringAesCipher : StringCipher {
+
     private val keyStore: KeyStore by lazy {
         KeyStore.getInstance(ANDROID_KEY_STORE).also {
             it.load(null)
@@ -27,37 +43,111 @@ class StringAesCipher : StringCipher {
 
     private lateinit var hmac: Mac
 
+    @Volatile
+    private var encryptionMode: EncryptionMode = EncryptionMode.UNINITIALIZED
+
+    private var softwareAesKey: SecretKey? = null
+    private var softwareIntegrityKey: SecretKey? = null
+
     override fun initialize(context: Context) {
-        if (::hmac.isInitialized) {
+        if (::hmac.isInitialized && encryptionMode != EncryptionMode.UNINITIALIZED) {
             return
         }
 
         synchronized(this) {
-            getAesSecretKey()
-            val integrityKey = getIntegrityKey()
+            if (::hmac.isInitialized && encryptionMode != EncryptionMode.UNINITIALIZED) {
+                return
+            }
 
-            hmac = Mac.getInstance(KeyProperties.KEY_ALGORITHM_HMAC_SHA256).apply {
-                init(integrityKey)
+            val prefs = getEncryptionPreferences(context)
+            val savedMode = prefs.getString(KEY_ENCRYPTION_MODE, null)
+
+            when (savedMode) {
+                MODE_SOFTWARE -> {
+                    initializeWithSoftwareKeys(context, prefs)
+                    return
+                }
+                else -> {
+                    // MODE_KEYSTORE or first run: try KeyStore with retry
+                    if (initializeWithKeyStore(context, prefs)) {
+                        return
+                    }
+                    // KeyStore failed: fallback to software
+                    initializeWithSoftwareKeys(context, prefs)
+                }
             }
         }
+    }
+
+    /**
+     * Try to initialize with Android KeyStore. Includes retry and StrongBox avoidance.
+     * @return true if successful, false if should fallback to software
+     */
+    private fun initializeWithKeyStore(context: Context, prefs: SharedPreferences): Boolean {
+        val maxRetries = 3
+        val retryDelayMs = 100L
+
+        repeat(maxRetries) { attempt ->
+            try {
+                val aesKey = getAesSecretKeyFromKeyStore()
+                val integrityKey = getIntegrityKeyFromKeyStore()
+
+                hmac = Mac.getInstance(KeyProperties.KEY_ALGORITHM_HMAC_SHA256).apply {
+                    init(integrityKey)
+                }
+                encryptionMode = EncryptionMode.KEYSTORE
+                prefs.edit().putString(KEY_ENCRYPTION_MODE, MODE_KEYSTORE).apply()
+                return true
+            } catch (e: Exception) {
+                if (attempt == maxRetries - 1) {
+                    return false
+                }
+                try {
+                    Thread.sleep(retryDelayMs)
+                } catch (ie: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return false
+                }
+            }
+        }
+        return false
+    }
+
+    private fun initializeWithSoftwareKeys(context: Context, prefs: SharedPreferences) {
+        val salt = getOrCreateSalt(prefs)
+        val (aesKey, integrityKey) = deriveSoftwareKeys(context, salt)
+
+        softwareAesKey = aesKey
+        softwareIntegrityKey = integrityKey
+
+        hmac = Mac.getInstance(KeyProperties.KEY_ALGORITHM_HMAC_SHA256).apply {
+            init(integrityKey)
+        }
+        encryptionMode = EncryptionMode.SOFTWARE
+        prefs.edit().putString(KEY_ENCRYPTION_MODE, MODE_SOFTWARE).apply()
     }
 
     override fun encrypt(context: Context, plainText: String): String {
         synchronized(this) {
             initialize(context)
 
-            try {
-                val secretKey = getAesSecretKey()
+            val secretKey = when (encryptionMode) {
+                EncryptionMode.KEYSTORE -> getAesSecretKeyFromKeyStore()
+                EncryptionMode.SOFTWARE -> softwareAesKey
+                    ?: throw EncryptionException("Software key not initialized")
+                EncryptionMode.UNINITIALIZED -> throw EncryptionException("Encryptor not initialized")
+            }
 
+            try {
                 val cipher = Cipher.getInstance(TRANSFORMATION_FORMAT).apply {
                     init(Cipher.ENCRYPT_MODE, secretKey)
                 }
-                val encryptedData: ByteArray = cipher.doFinal(plainText.toByteArray())
+                val encryptedData: ByteArray = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
 
                 return CipherData(
                     encryptedData = encryptedData,
-                    initialVector = cipher.iv,
-                    hmacValue = hmac.calculateHmacValue(encryptedData, cipher.iv)
+                    initialVector = cipher.iv!!,
+                    hmacValue = hmac.calculateHmacValue(encryptedData, cipher.iv!!)
                 ).encodeToBase64String()
             } catch (e: Exception) {
                 throw EncryptionException("Failed to encrypt", e)
@@ -67,9 +157,16 @@ class StringAesCipher : StringCipher {
 
     override fun decrypt(context: Context, cipherText: String): String {
         synchronized(this) {
-            try {
-                val secretKey = getAesSecretKey()
+            initialize(context)
 
+            val secretKey = when (encryptionMode) {
+                EncryptionMode.KEYSTORE -> getAesSecretKeyFromKeyStore()
+                EncryptionMode.SOFTWARE -> softwareAesKey
+                    ?: throw EncryptionException("Software key not initialized")
+                EncryptionMode.UNINITIALIZED -> throw EncryptionException("Encryptor not initialized")
+            }
+
+            try {
                 val cipherData = CipherData.decodeFromBase64String(cipherText)
 
                 cipherData.verifyHmacValue(hmac)
@@ -79,31 +176,27 @@ class StringAesCipher : StringCipher {
                 return Cipher.getInstance(TRANSFORMATION_FORMAT)
                     .apply { init(Cipher.DECRYPT_MODE, secretKey, ivSpec) }
                     .run { doFinal(cipherData.encryptedData) }
-                    .let {
-                        String(it)
-                    }
+                    .let { String(it, Charsets.UTF_8) }
             } catch (e: Exception) {
                 throw EncryptionException("Failed to decrypt", e)
             }
         }
     }
 
-    private fun getAesSecretKey(): SecretKey {
+    private fun getAesSecretKeyFromKeyStore(): SecretKey {
         return if (keyStore.containsAlias(AES_KEY_ALIAS)) {
             val secretKeyEntry =
                 keyStore.getEntry(AES_KEY_ALIAS, null) as KeyStore.SecretKeyEntry
-
             secretKeyEntry.secretKey
         } else {
             createAesKey()
         }
     }
 
-    private fun getIntegrityKey(): SecretKey {
+    private fun getIntegrityKeyFromKeyStore(): SecretKey {
         return if (keyStore.containsAlias(INTEGRITY_KEY_ALIAS)) {
             val secretKeyEntry =
                 keyStore.getEntry(INTEGRITY_KEY_ALIAS, null) as KeyStore.SecretKeyEntry
-
             secretKeyEntry.secretKey
         } else {
             createIntegrityKey()
@@ -111,41 +204,95 @@ class StringAesCipher : StringCipher {
     }
 
     /**
-     * Create a new AES key in the Android KeyStore. This key will be used for
-     * encrypting and decrypting data. The key is generated with a size of 256 bits,
-     * using the CBC block mode and PKCS7 padding.
+     * Create a new AES key in the Android KeyStore.
+     * Uses setIsStrongBoxBacked(false) on API 28+ to avoid StrongBox communication failures.
      */
     private fun createAesKey(): SecretKey {
         val keyGenerator = KeyGenerator
             .getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
-        val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+
+        val builder = KeyGenParameterSpec.Builder(
             AES_KEY_ALIAS,
             PURPOSE_ENCRYPT or PURPOSE_DECRYPT
         )
             .setKeySize(KEY_SIZE_IN_BIT)
             .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
             .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-            .build()
 
-        keyGenerator.run {
-            init(keyGenParameterSpec)
-            return generateKey()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            builder.setIsStrongBoxBacked(false)
         }
+
+        keyGenerator.init(builder.build())
+        return keyGenerator.generateKey()
     }
 
+    /**
+     * Create HMAC key in Android KeyStore.
+     * Uses setIsStrongBoxBacked(false) on API 28+ to avoid StrongBox communication failures.
+     */
     private fun createIntegrityKey(): SecretKey {
         val keyGenerator = KeyGenerator
             .getInstance(KeyProperties.KEY_ALGORITHM_HMAC_SHA256, ANDROID_KEY_STORE)
-        val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+
+        val builder = KeyGenParameterSpec.Builder(
             INTEGRITY_KEY_ALIAS,
             PURPOSE_SIGN or PURPOSE_VERIFY
         )
-            .build()
 
-        keyGenerator.run {
-            init(keyGenParameterSpec)
-            return generateKey()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            builder.setIsStrongBoxBacked(false)
         }
+
+        keyGenerator.init(builder.build())
+        return keyGenerator.generateKey()
+    }
+
+    private fun getEncryptionPreferences(context: Context): SharedPreferences {
+        return context.getSharedPreferences(SHARED_PREFS_ENCRYPTION, Context.MODE_PRIVATE)
+    }
+
+    private fun getOrCreateSalt(prefs: SharedPreferences): ByteArray {
+        val savedSalt = prefs.getString(KEY_SALT, null)
+        if (!savedSalt.isNullOrEmpty()) {
+            return Base64.decode(savedSalt, Base64.NO_WRAP)
+        }
+        val salt = ByteArray(SALT_SIZE_BYTES).also { SecureRandom().nextBytes(it) }
+        prefs.edit().putString(KEY_SALT, Base64.encodeToString(salt, Base64.NO_WRAP)).apply()
+        return salt
+    }
+
+    @SuppressLint("HardwareIds")
+    private fun generateDevicePackageSpecificId(context: Context): String {
+        val androidId = Settings.Secure.getString(
+            context.contentResolver,
+            Settings.Secure.ANDROID_ID
+        ) ?: ""
+        return "${Build.MODEL}${Build.MANUFACTURER}$androidId${context.packageName}"
+    }
+
+    private fun deriveSoftwareKeys(context: Context, salt: ByteArray): Pair<SecretKey, SecretKey> {
+        val deviceId = generateDevicePackageSpecificId(context)
+        val spec: KeySpec = PBEKeySpec(
+            deviceId.toCharArray(),
+            salt,
+            PBKDF2_ITERATIONS,
+            AES_KEY_SIZE_BITS + HMAC_KEY_SIZE_BITS
+        )
+
+        val keyFactory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
+        val keyBytes = keyFactory.generateSecret(spec).encoded!!
+
+        val aesKey = SecretKeySpec(
+            keyBytes.copyOfRange(0, AES_KEY_SIZE_BITS / 8),
+            "AES"
+        )
+        val integrityKey = SecretKeySpec(
+            keyBytes.copyOfRange(AES_KEY_SIZE_BITS / 8, keyBytes.size),
+            "HmacSHA256"
+        )
+
+        return aesKey to integrityKey
     }
 
     private fun Mac.calculateHmacValue(
@@ -153,13 +300,8 @@ class StringAesCipher : StringCipher {
         initialVector: ByteArray
     ): ByteArray = doFinal(encryptedData + initialVector)
 
-    /**
-     * Validate the HMAC value
-     *
-     * @throws SecurityException if the HMAC value doesn't match with [encryptedData]
-     */
     private fun CipherData.verifyHmacValue(mac: Mac) {
-        val expectedHmacValue: ByteArray = mac.calculateHmacValue(
+        val expectedHmacValue = mac.calculateHmacValue(
             encryptedData = encryptedData,
             initialVector = initialVector
         )
@@ -167,6 +309,12 @@ class StringAesCipher : StringCipher {
         if (!MessageDigest.isEqual(expectedHmacValue, hmacValue)) {
             throw SecurityException("Cipher text has been tampered with.")
         }
+    }
+
+    private enum class EncryptionMode {
+        UNINITIALIZED,
+        KEYSTORE,
+        SOFTWARE
     }
 
     companion object {
@@ -180,8 +328,19 @@ class StringAesCipher : StringCipher {
         private const val KEY_SIZE_IN_BIT = 256
 
         private const val TRANSFORMATION_FORMAT =
-            KeyProperties.KEY_ALGORITHM_AES +
-                "/${KeyProperties.BLOCK_MODE_CBC}" +
-                "/${KeyProperties.ENCRYPTION_PADDING_PKCS7}"
+            "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_CBC}/${KeyProperties.ENCRYPTION_PADDING_PKCS7}"
+
+        private const val SHARED_PREFS_ENCRYPTION = "com.linecorp.linesdk.encryption"
+        private const val KEY_ENCRYPTION_MODE = "encryption_mode"
+        private const val KEY_SALT = "salt"
+
+        private const val MODE_KEYSTORE = "keystore"
+        private const val MODE_SOFTWARE = "software"
+
+        private const val SALT_SIZE_BYTES = 16
+        private const val PBKDF2_ITERATIONS = 10000
+        private const val PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA1"
+        private const val AES_KEY_SIZE_BITS = 256
+        private const val HMAC_KEY_SIZE_BITS = 256
     }
 }


### PR DESCRIPTION
## Description

Fixes #186

This PR addresses crashes caused by Android KeyStore failures (`InvalidKeyException`, `ProviderException: Keystore key generation failed`, `SECURE_HW_COMMUNICATION_FAILED`, etc.) on certain devices (particularly Xiaomi, POCO, Redmi on Android 14–16). When KeyStore hardware communication fails, the SDK now falls back to software-backed encryption so that the app flow continues without crashing.

## Root Cause

- Android KeyStore relies on secure hardware (TEE/StrongBox). On some devices and OS versions, communication with this hardware fails.
- Reported mainly on Android 14–16 with Xiaomi/POCO/Redmi devices.
- Reference: [Android KeyStore Issue #229764028](https://issuetracker.google.com/issues/229764028)

## Solution Overview

1. **Encryption mode**: `KEYSTORE` (default) or `SOFTWARE` (fallback)
2. **Retry**: Up to 3 attempts with 100 ms delay before giving up on KeyStore
3. **StrongBox bypass**: `setIsStrongBoxBacked(false)` on API 28+ to avoid StrongBox-related failures
4. **Software fallback**: PBKDF2-derived keys (device-specific ID + salt) when KeyStore fails
5. **Mode persistence**: Encryption mode and salt are stored in SharedPreferences across app sessions

## Flow

```
initialize(context)
  |
  +-- savedMode == SOFTWARE
  |       +-- Use software keys only (no KeyStore access)
  |
  +-- savedMode == KEYSTORE or first run
  |       |
  |       +-- Try KeyStore init (retry up to 3 times, 100ms delay)
  |       |   +-- Uses setIsStrongBoxBacked(false) on API 28+
  |       |
  |       +-- Success -> KEYSTORE mode, continue as before
  |       |
  |       +-- Failure -> Fall back to SOFTWARE
  |               +-- Derive AES + HMAC keys via PBKDF2 (device ID + salt)
  |               +-- Store mode and salt in SharedPreferences
  |               +-- Use software keys for encrypt/decrypt
  |
encrypt/decrypt
  +-- Use KeyStore keys or software keys depending on current mode
```

## Technical Details

- **CipherData format**: Unchanged (`encryptedData;iv;hmac`), so compatibility is preserved
- **Security**: Software mode uses PBKDF2 (10,000 iterations) with device-specific ID and a random salt
- **Migration**: If a device switches from KEYSTORE to SOFTWARE after a failure, previously KeyStore-encrypted data cannot be decrypted (as before). `AccessTokenCache` treats decryption failures as cache invalidation and clears the cache, requiring the user to log in again.

## Testing

- Verified with the existing `TestStringCipher` and `AccessTokenCache` tests
- No changes to public API or `EncryptorHolder`